### PR TITLE
Implement FBC-12 onboarding state routing

### DIFF
--- a/src/main/java/com/frankies/bootcamp/filter/AuthenticationFilter.java
+++ b/src/main/java/com/frankies/bootcamp/filter/AuthenticationFilter.java
@@ -16,7 +16,7 @@ import java.util.Set;
 public class AuthenticationFilter implements Filter {
     private static final Set<String> PUBLIC_PATHS = Set.of(
             "/", "/index.jsp", "/privacy", "/privacy.jsp", "/terms", "/terms.jsp", "/scoring", "/scoring.jsp",
-            "/login", "/logout", "/error.jsp", "/api/strava/webhook",
+            "/login", "/logout", "/join", "/join.jsp", "/error.jsp", "/api/strava/webhook",
             "/auth/external/login", "/auth/external/callback", "/app/whoami.jsp"
     );
 

--- a/src/main/java/com/frankies/bootcamp/model/OnboardingState.java
+++ b/src/main/java/com/frankies/bootcamp/model/OnboardingState.java
@@ -1,0 +1,8 @@
+package com.frankies.bootcamp.model;
+
+public enum OnboardingState {
+    AUTHENTICATED,
+    STRAVA_PENDING,
+    COMPETITION_PENDING,
+    READY
+}

--- a/src/main/java/com/frankies/bootcamp/model/OnboardingStatus.java
+++ b/src/main/java/com/frankies/bootcamp/model/OnboardingStatus.java
@@ -1,0 +1,34 @@
+package com.frankies.bootcamp.model;
+
+public class OnboardingStatus {
+    private final OnboardingState state;
+    private final boolean appUserReady;
+    private final boolean stravaLinked;
+    private final boolean hasCompetitionMembership;
+
+    public OnboardingStatus(OnboardingState state,
+                            boolean appUserReady,
+                            boolean stravaLinked,
+                            boolean hasCompetitionMembership) {
+        this.state = state;
+        this.appUserReady = appUserReady;
+        this.stravaLinked = stravaLinked;
+        this.hasCompetitionMembership = hasCompetitionMembership;
+    }
+
+    public OnboardingState getState() {
+        return state;
+    }
+
+    public boolean isAppUserReady() {
+        return appUserReady;
+    }
+
+    public boolean isStravaLinked() {
+        return stravaLinked;
+    }
+
+    public boolean hasCompetitionMembership() {
+        return hasCompetitionMembership;
+    }
+}

--- a/src/main/java/com/frankies/bootcamp/service/DBService.java
+++ b/src/main/java/com/frankies/bootcamp/service/DBService.java
@@ -679,10 +679,41 @@ public class DBService {
         throw new SQLException("Unable to find competition_athlete for athlete " + athleteId);
     }
 
+    public Long findActiveCompetitionAthleteId(String athleteId) throws SQLException {
+        try (
+                Connection connection = ds.getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT id FROM competition_athlete WHERE athlete_id = ? AND status = 'active' ORDER BY id ASC LIMIT 1"
+                )
+        ) {
+            statement.setString(1, athleteId);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (resultSet.next()) {
+                    return resultSet.getLong("id");
+                }
+            }
+        }
+        return null;
+    }
+
     private boolean isFirstCompetitionAthlete(Connection connection) throws SQLException {
         try (PreparedStatement statement = connection.prepareStatement("SELECT COUNT(*) FROM competition_athlete WHERE competition_id = 1")) {
             try (ResultSet resultSet = statement.executeQuery()) {
                 return resultSet.next() && resultSet.getInt(1) == 0;
+            }
+        }
+    }
+
+    public boolean hasActiveCompetitionMembership(String athleteId) throws SQLException {
+        try (
+                Connection connection = ds.getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT 1 FROM competition_athlete WHERE athlete_id = ? AND status = 'active' LIMIT 1"
+                )
+        ) {
+            statement.setString(1, athleteId);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                return resultSet.next();
             }
         }
     }

--- a/src/main/java/com/frankies/bootcamp/service/OnboardingStateService.java
+++ b/src/main/java/com/frankies/bootcamp/service/OnboardingStateService.java
@@ -1,0 +1,51 @@
+package com.frankies.bootcamp.service;
+
+import com.frankies.bootcamp.model.AuthenticatedUser;
+import com.frankies.bootcamp.model.BootcampAthlete;
+import com.frankies.bootcamp.model.OnboardingState;
+import com.frankies.bootcamp.model.OnboardingStatus;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.sql.SQLException;
+
+@ApplicationScoped
+public class OnboardingStateService {
+    @FunctionalInterface
+    public interface CompetitionMembershipLookup {
+        boolean hasActiveCompetitionMembership(String athleteId) throws SQLException;
+    }
+
+    private CompetitionMembershipLookup competitionMembershipLookup;
+
+    @Inject
+    public OnboardingStateService(DBService dbService) {
+        this.competitionMembershipLookup = dbService::hasActiveCompetitionMembership;
+    }
+
+    OnboardingStateService(CompetitionMembershipLookup competitionMembershipLookup) {
+        this.competitionMembershipLookup = competitionMembershipLookup;
+    }
+
+    protected OnboardingStateService() {
+    }
+
+    public OnboardingStatus resolve(AuthenticatedUser user, BootcampAthlete athlete) throws SQLException {
+        boolean appUserReady = user != null && user.getUserId() != null && !user.getUserId().isBlank();
+        boolean stravaLinked = athlete != null && athlete.getId() != null && !athlete.getId().isBlank() && !athlete.getId().startsWith("local-");
+        boolean hasCompetitionMembership = stravaLinked && competitionMembershipLookup.hasActiveCompetitionMembership(athlete.getId());
+
+        OnboardingState state;
+        if (!appUserReady) {
+            state = OnboardingState.AUTHENTICATED;
+        } else if (!stravaLinked) {
+            state = OnboardingState.STRAVA_PENDING;
+        } else if (!hasCompetitionMembership) {
+            state = OnboardingState.COMPETITION_PENDING;
+        } else {
+            state = OnboardingState.READY;
+        }
+
+        return new OnboardingStatus(state, appUserReady, stravaLinked, hasCompetitionMembership);
+    }
+}

--- a/src/main/java/com/frankies/bootcamp/service/PersistentActivityProcessService.java
+++ b/src/main/java/com/frankies/bootcamp/service/PersistentActivityProcessService.java
@@ -57,6 +57,9 @@ public class PersistentActivityProcessService {
             if (athlete.getId() == null || athlete.getId().isBlank() || athlete.getId().startsWith("local-")) {
                 continue;
             }
+            if (!hasActiveCompetitionMembership(athlete.getId())) {
+                continue;
+            }
             rebuildAthleteState(athlete);
         }
         persistHonourRollRows();
@@ -67,6 +70,9 @@ public class PersistentActivityProcessService {
         if (athlete == null || athlete.getId() == null || athlete.getId().isBlank() || athlete.getId().startsWith("local-")) {
             return;
         }
+        if (!hasActiveCompetitionMembership(athlete.getId())) {
+            return;
+        }
         rebuildAthleteState(athlete);
         persistHonourRollRows();
         regenerateSummaryMaps();
@@ -75,7 +81,13 @@ public class PersistentActivityProcessService {
     protected PerformanceResponse rebuildAthleteState(BootcampAthlete athlete) throws SQLException, CredentialStoreException, NoSuchAlgorithmException, IOException {
         BootcampAthlete refreshedAthlete = stravaService.refreshToken(athlete);
         LOG.info("Busy with athlete: " + refreshedAthlete.getFirstname() + " " + refreshedAthlete.getLastname());
-        long competitionAthleteId = ensureCompetitionAthlete(refreshedAthlete);
+        Long competitionAthleteId = getActiveCompetitionAthleteId(refreshedAthlete);
+        if (competitionAthleteId == null) {
+            LOG.info("Skipping persistent rebuild for athlete without active competition membership: " + refreshedAthlete.getId());
+            PerformanceResponse performance = new PerformanceResponse();
+            performance.setAthlete(refreshedAthlete);
+            return performance;
+        }
         List<StravaActivityResponse> activities = stravaService.getAthleteActivitiesForPeriod(getStartTimeStamp(), refreshedAthlete.getAccessToken());
 
         PerformanceResponse performance = new PerformanceResponse();
@@ -157,8 +169,12 @@ public class PersistentActivityProcessService {
         return performance;
     }
 
-    protected long ensureCompetitionAthlete(BootcampAthlete athlete) throws SQLException {
-        return dbService.ensureCompetitionAthlete(athlete.getId(), athlete.getGoal());
+    protected Long getActiveCompetitionAthleteId(BootcampAthlete athlete) throws SQLException {
+        return dbService.findActiveCompetitionAthleteId(athlete.getId());
+    }
+
+    protected boolean hasActiveCompetitionMembership(String athleteId) throws SQLException {
+        return dbService.hasActiveCompetitionMembership(athleteId);
     }
 
     protected void replacePersistentCompetitionState(long competitionAthleteId,

--- a/src/main/java/com/frankies/bootcamp/servlet/Auth0LoginServlet.java
+++ b/src/main/java/com/frankies/bootcamp/servlet/Auth0LoginServlet.java
@@ -22,6 +22,7 @@ public class Auth0LoginServlet extends HttpServlet {
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
         String state = randomToken();
         req.getSession(true).setAttribute("auth0State", state);
+        String prompt = req.getParameter("prompt");
 
         String authorizeUrl = "https://" + config.getDomain() + "/authorize"
                 + "?response_type=code"
@@ -29,6 +30,10 @@ public class Auth0LoginServlet extends HttpServlet {
                 + "&redirect_uri=" + url(config.getBaseUrl() + req.getContextPath() + "/auth/external/callback")
                 + "&scope=" + url("openid profile email")
                 + "&state=" + url(state);
+
+        if (prompt != null && !prompt.isBlank()) {
+            authorizeUrl += "&prompt=" + url(prompt);
+        }
 
         resp.sendRedirect(authorizeUrl);
     }

--- a/src/main/java/com/frankies/bootcamp/servlet/BootcampServlet.java
+++ b/src/main/java/com/frankies/bootcamp/servlet/BootcampServlet.java
@@ -2,7 +2,10 @@ package com.frankies.bootcamp.servlet;
 
 import com.frankies.bootcamp.model.BootcampAthlete;
 import com.frankies.bootcamp.model.AuthenticatedUser;
+import com.frankies.bootcamp.model.OnboardingState;
+import com.frankies.bootcamp.model.OnboardingStatus;
 import com.frankies.bootcamp.service.AuthService;
+import com.frankies.bootcamp.service.OnboardingStateService;
 import com.frankies.bootcamp.service.StravaService;
 import com.frankies.bootcamp.service.AuthSessionService;
 import jakarta.inject.Inject;
@@ -20,6 +23,8 @@ public class BootcampServlet extends HttpServlet {
     @Inject
     private AuthService authService;
     @Inject
+    private OnboardingStateService onboardingStateService;
+    @Inject
     private StravaService stravaService;
 
     private static final Logger log = Logger.getLogger(BootcampServlet.class);
@@ -29,39 +34,38 @@ public class BootcampServlet extends HttpServlet {
             throws ServletException, IOException {
 
         HttpSession session = req.getSession(true);
-        BootcampAthlete athlete = (BootcampAthlete) session.getAttribute("athlete");
         AuthenticatedUser authenticatedUser = authSessionService.getAuthenticatedUser(req);
+        BootcampAthlete athlete = null;
 
-        if (athlete == null) {
-            if (authenticatedUser == null || authenticatedUser.getEmail() == null || authenticatedUser.getEmail().isBlank()) {
-                unauthorized(resp, "Login required");
+        if (authenticatedUser == null || authenticatedUser.getEmail() == null || authenticatedUser.getEmail().isBlank()) {
+            unauthorized(resp, "Login required");
+            return;
+        }
+
+        try {
+            athlete = authService.loadAthleteForUser(authenticatedUser);
+            OnboardingStatus onboardingStatus = onboardingStateService.resolve(authenticatedUser, athlete);
+            applyOnboardingAttributes(req, session, authenticatedUser, athlete, onboardingStatus);
+
+            if (onboardingStatus.getState() == OnboardingState.STRAVA_PENDING) {
+                log.info("Strava link required: " + authenticatedUser.getEmail());
+                forwardToStravaOnboarding(req, resp, authenticatedUser, onboardingStatus);
                 return;
             }
-            try {
-                athlete = authService.loadAthleteForUser(authenticatedUser);
-                if (athlete == null || isStravaPending(athlete)) {
-                    log.info("Strava link required: " + authenticatedUser.getEmail());
-                    // Use StravaService to provide server-controlled config
-                    String clientId = stravaService.getClientId();
-                    String callback = stravaService.buildCallbackUrl(req);
 
-                    req.setAttribute("stravaClientId", clientId);
-                    req.setAttribute("stravaCallback", callback);
-                    req.setAttribute("stravaOnboardingUser", authenticatedUser);
-                    req.getRequestDispatcher("/app/strava-onboarding.jsp").forward(req, resp);
-                    return;
-                }
+            if (onboardingStatus.getState() == OnboardingState.COMPETITION_PENDING) {
+                log.info("Competition onboarding required: " + authenticatedUser.getEmail());
+                req.getRequestDispatcher("/app/competition-onboarding.jsp").forward(req, resp);
+                return;
+            }
 
-                // Cache in session for future requests
-                session.setAttribute("athlete", athlete);
-                session.setAttribute("athleteEmail", authenticatedUser.getEmail());
-                session.setAttribute("athleteName", authenticatedUser.getDisplayName());
+            if (athlete != null) {
                 log.info("Athlete authorised: " + buildDisplayName(athlete, authenticatedUser.getEmail()));
-            } catch (SQLException e) {
-                log.error("Error looking up athlete by email", e);
-                resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-                return;
             }
+        } catch (SQLException e) {
+            log.error("Error resolving onboarding state", e);
+            resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            return;
         }
 
         // Expose on the request for convenience
@@ -97,8 +101,31 @@ public class BootcampServlet extends HttpServlet {
         }
     }
 
-    private boolean isStravaPending(BootcampAthlete athlete) {
-        return athlete.getId() == null || athlete.getId().isBlank() || athlete.getId().startsWith("local-");
+    private void forwardToStravaOnboarding(HttpServletRequest req,
+                                           HttpServletResponse resp,
+                                           AuthenticatedUser authenticatedUser,
+                                           OnboardingStatus onboardingStatus) throws ServletException, IOException {
+        String clientId = stravaService.getClientId();
+        String callback = stravaService.buildCallbackUrl(req);
+
+        req.setAttribute("stravaClientId", clientId);
+        req.setAttribute("stravaCallback", callback);
+        req.setAttribute("stravaOnboardingUser", authenticatedUser);
+        req.setAttribute("onboardingStatus", onboardingStatus);
+        req.getRequestDispatcher("/app/strava-onboarding.jsp").forward(req, resp);
+    }
+
+    private void applyOnboardingAttributes(HttpServletRequest req,
+                                           HttpSession session,
+                                           AuthenticatedUser authenticatedUser,
+                                           BootcampAthlete athlete,
+                                           OnboardingStatus onboardingStatus) {
+        req.setAttribute("onboardingStatus", onboardingStatus);
+        req.setAttribute("onboardingState", onboardingStatus.getState());
+
+        session.setAttribute("athlete", athlete);
+        session.setAttribute("athleteEmail", authenticatedUser.getEmail());
+        session.setAttribute("athleteName", authenticatedUser.getDisplayName());
     }
 
 }

--- a/src/main/java/com/frankies/bootcamp/servlet/JoinServlet.java
+++ b/src/main/java/com/frankies/bootcamp/servlet/JoinServlet.java
@@ -1,0 +1,16 @@
+package com.frankies.bootcamp.servlet;
+
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+@WebServlet(name = "join", value = "/join")
+public class JoinServlet extends HttpServlet {
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        resp.sendRedirect(req.getContextPath() + "/auth/external/login?prompt=login");
+    }
+}

--- a/src/main/java/com/frankies/bootcamp/servlet/LoginServlet.java
+++ b/src/main/java/com/frankies/bootcamp/servlet/LoginServlet.java
@@ -11,10 +11,10 @@ import java.io.IOException;
 public class LoginServlet extends HttpServlet {
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-        String destination = req.getContextPath() + "/auth/external/login";
+        String destination = req.getContextPath() + "/auth/external/login?prompt=login";
         String error = req.getParameter("error");
         if (error != null && !error.isBlank()) {
-            destination += "?error=" + java.net.URLEncoder.encode(error, java.nio.charset.StandardCharsets.UTF_8);
+            destination += "&error=" + java.net.URLEncoder.encode(error, java.nio.charset.StandardCharsets.UTF_8);
         }
         resp.sendRedirect(destination);
     }

--- a/src/main/webapp/app/competition-onboarding.jsp
+++ b/src/main/webapp/app/competition-onboarding.jsp
@@ -1,0 +1,66 @@
+<%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%@ page import="com.frankies.bootcamp.model.AuthenticatedUser" %>
+<%@ page import="com.frankies.bootcamp.model.OnboardingStatus" %>
+<%
+    AuthenticatedUser onboardingUser = (AuthenticatedUser) session.getAttribute("authUser");
+    OnboardingStatus onboardingStatus = (OnboardingStatus) request.getAttribute("onboardingStatus");
+    String displayName = (onboardingUser == null || onboardingUser.getDisplayName() == null || onboardingUser.getDisplayName().isBlank())
+            ? "there"
+            : onboardingUser.getDisplayName();
+    String pageContextPath = request.getContextPath();
+%>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <%@ include file="/WEB-INF/jspf/head-common.jspf" %>
+    <title>Finish onboarding</title>
+</head>
+<body class="bg-light">
+<header class="d-flex align-items-center justify-content-between text-white px-3 py-2 shadow-sm"
+        style="min-height:56px; background-color: #0d6efd;">
+    <a href="<%=pageContextPath%>/" class="text-white text-decoration-none d-flex align-items-center gap-2">
+        <span aria-hidden="true">&#x1F3CB;&#xFE0F;</span>
+        <span>Frankies Bootcamp!</span>
+    </a>
+</header>
+
+<div class="container py-5">
+    <div class="row justify-content-center">
+        <div class="col-lg-8">
+            <div class="card shadow-sm border-0">
+                <div class="card-body p-4 p-md-5">
+                    <div class="text-center mb-4">
+                        <div class="display-5 text-primary mb-3"><i class="bi bi-flag"></i></div>
+                        <h1 class="h3 mb-3">One more step, <%= displayName %></h1>
+                        <p class="text-muted mb-0">
+                            Your account is authenticated and linked to Strava, but you are not in an active competition yet.
+                        </p>
+                    </div>
+
+                    <div class="alert alert-primary" role="alert">
+                        Current onboarding state: <strong><%= onboardingStatus == null ? "competition-pending" : onboardingStatus.getState() %></strong>
+                    </div>
+
+                    <p class="mb-3">
+                        Competition join/create flows are not fully landed yet. For now, this state is explicit so the app does not treat you as fully onboarded too early.
+                    </p>
+
+                    <ul class="text-muted">
+                        <li>Your app user is ready.</li>
+                        <li>Your Strava link is complete.</li>
+                        <li>Your next step is competition eligibility, invite, join, or setup.</li>
+                    </ul>
+
+                    <div class="d-grid gap-2 d-sm-flex justify-content-sm-center mt-4">
+                        <a class="btn btn-outline-secondary btn-lg" href="<%=pageContextPath%>/logout">Sign out</a>
+                        <a class="btn btn-primary btn-lg" href="<%=pageContextPath%>/app">Retry onboarding check</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/test/java/com/frankies/bootcamp/auth/AuthenticationFilterTest.java
+++ b/src/test/java/com/frankies/bootcamp/auth/AuthenticationFilterTest.java
@@ -1,0 +1,184 @@
+package com.frankies.bootcamp.auth;
+
+import com.frankies.bootcamp.filter.AuthenticationFilter;
+import com.frankies.bootcamp.service.AuthSessionService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.lang.reflect.Field;
+import java.security.Principal;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AuthenticationFilterTest {
+
+    @Test
+    void joinPathIsPublicWhenLoggedOut() throws Exception {
+        AuthenticationFilter filter = new AuthenticationFilter();
+        injectAuthSessionService(filter, new AuthSessionService());
+
+        FakeHttpServletRequest request = new FakeHttpServletRequest("/bootcamp", "/bootcamp/join", null);
+        FakeHttpServletResponse response = new FakeHttpServletResponse();
+        RecordingFilterChain chain = new RecordingFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertTrue(chain.called);
+        assertFalse(response.redirected);
+    }
+
+    private static void injectAuthSessionService(AuthenticationFilter filter, AuthSessionService authSessionService) throws Exception {
+        Field field = AuthenticationFilter.class.getDeclaredField("authSessionService");
+        field.setAccessible(true);
+        field.set(filter, authSessionService);
+    }
+
+    private static final class RecordingFilterChain implements FilterChain {
+        private boolean called;
+
+        @Override
+        public void doFilter(ServletRequest request, ServletResponse response) {
+            called = true;
+        }
+    }
+
+    private static final class FakeHttpServletRequest implements HttpServletRequest {
+        private final String contextPath;
+        private final String requestUri;
+        private final HttpSession session;
+
+        private FakeHttpServletRequest(String contextPath, String requestUri, HttpSession session) {
+            this.contextPath = contextPath;
+            this.requestUri = requestUri;
+            this.session = session;
+        }
+
+        @Override public String getRequestURI() { return requestUri; }
+        @Override public String getContextPath() { return contextPath; }
+        @Override public HttpSession getSession(boolean create) { return session; }
+        @Override public HttpSession getSession() { return session; }
+        @Override public Object getAttribute(String name) { return null; }
+        @Override public Enumeration<String> getAttributeNames() { return Collections.emptyEnumeration(); }
+        @Override public String getCharacterEncoding() { return null; }
+        @Override public void setCharacterEncoding(String env) {}
+        @Override public int getContentLength() { return 0; }
+        @Override public long getContentLengthLong() { return 0; }
+        @Override public String getContentType() { return null; }
+        @Override public jakarta.servlet.ServletInputStream getInputStream() { return null; }
+        @Override public String getParameter(String name) { return null; }
+        @Override public Enumeration<String> getParameterNames() { return Collections.emptyEnumeration(); }
+        @Override public String[] getParameterValues(String name) { return new String[0]; }
+        @Override public Map<String, String[]> getParameterMap() { return new HashMap<>(); }
+        @Override public String getProtocol() { return null; }
+        @Override public String getScheme() { return null; }
+        @Override public String getServerName() { return null; }
+        @Override public int getServerPort() { return 0; }
+        @Override public BufferedReader getReader() { return null; }
+        @Override public String getRemoteAddr() { return null; }
+        @Override public String getRemoteHost() { return null; }
+        @Override public void setAttribute(String name, Object o) {}
+        @Override public void removeAttribute(String name) {}
+        @Override public Locale getLocale() { return Locale.getDefault(); }
+        @Override public Enumeration<Locale> getLocales() { return Collections.enumeration(Collections.singletonList(Locale.getDefault())); }
+        @Override public boolean isSecure() { return false; }
+        @Override public jakarta.servlet.RequestDispatcher getRequestDispatcher(String path) { return null; }
+        @Override public int getRemotePort() { return 0; }
+        @Override public String getLocalName() { return null; }
+        @Override public String getLocalAddr() { return null; }
+        @Override public int getLocalPort() { return 0; }
+        @Override public jakarta.servlet.ServletContext getServletContext() { return null; }
+        @Override public jakarta.servlet.AsyncContext startAsync() { return null; }
+        @Override public jakarta.servlet.AsyncContext startAsync(ServletRequest servletRequest, ServletResponse servletResponse) { return null; }
+        @Override public boolean isAsyncStarted() { return false; }
+        @Override public boolean isAsyncSupported() { return false; }
+        @Override public jakarta.servlet.AsyncContext getAsyncContext() { return null; }
+        @Override public jakarta.servlet.DispatcherType getDispatcherType() { return null; }
+        @Override public String getAuthType() { return null; }
+        @Override public Cookie[] getCookies() { return new Cookie[0]; }
+        @Override public long getDateHeader(String name) { return 0; }
+        @Override public String getHeader(String name) { return null; }
+        @Override public Enumeration<String> getHeaders(String name) { return Collections.emptyEnumeration(); }
+        @Override public Enumeration<String> getHeaderNames() { return Collections.emptyEnumeration(); }
+        @Override public int getIntHeader(String name) { return 0; }
+        @Override public String getMethod() { return "GET"; }
+        @Override public String getPathInfo() { return null; }
+        @Override public String getPathTranslated() { return null; }
+        @Override public String getQueryString() { return null; }
+        @Override public String getRemoteUser() { return null; }
+        @Override public boolean isUserInRole(String role) { return false; }
+        @Override public Principal getUserPrincipal() { return null; }
+        @Override public String getRequestedSessionId() { return null; }
+        @Override public String getServletPath() { return null; }
+        @Override public StringBuffer getRequestURL() { return new StringBuffer(requestUri); }
+        @Override public boolean isRequestedSessionIdValid() { return false; }
+        @Override public boolean isRequestedSessionIdFromCookie() { return false; }
+        @Override public boolean isRequestedSessionIdFromURL() { return false; }
+        @Override public boolean authenticate(HttpServletResponse response) { return false; }
+        @Override public void login(String username, String password) {}
+        @Override public void logout() {}
+        @Override public Collection<jakarta.servlet.http.Part> getParts() { return Collections.emptyList(); }
+        @Override public jakarta.servlet.http.Part getPart(String name) { return null; }
+        @Override public <T extends jakarta.servlet.http.HttpUpgradeHandler> T upgrade(Class<T> handlerClass) { return null; }
+        @Override public String changeSessionId() { return null; }
+        @Override public String getRequestId() { return null; }
+        @Override public String getProtocolRequestId() { return null; }
+        @Override public jakarta.servlet.ServletConnection getServletConnection() { return null; }
+    }
+
+    private static final class FakeHttpServletResponse implements HttpServletResponse {
+        private boolean redirected;
+
+        @Override public void sendRedirect(String location) { redirected = true; }
+        @Override public void sendRedirect(String location, int sc, boolean clearBuffer) { redirected = true; }
+        @Override public void addCookie(Cookie cookie) {}
+        @Override public boolean containsHeader(String name) { return false; }
+        @Override public String encodeURL(String url) { return url; }
+        @Override public String encodeRedirectURL(String url) { return url; }
+        @Override public void sendError(int sc, String msg) {}
+        @Override public void sendError(int sc) {}
+        @Override public void setDateHeader(String name, long date) {}
+        @Override public void addDateHeader(String name, long date) {}
+        @Override public void setHeader(String name, String value) {}
+        @Override public void addHeader(String name, String value) {}
+        @Override public void setIntHeader(String name, int value) {}
+        @Override public void addIntHeader(String name, int value) {}
+        @Override public void setStatus(int sc) {}
+        @Override public int getStatus() { return 0; }
+        @Override public String getHeader(String name) { return null; }
+        @Override public Collection<String> getHeaders(String name) { return Collections.emptyList(); }
+        @Override public Collection<String> getHeaderNames() { return Collections.emptyList(); }
+        @Override public String getCharacterEncoding() { return null; }
+        @Override public String getContentType() { return null; }
+        @Override public jakarta.servlet.ServletOutputStream getOutputStream() { return null; }
+        @Override public PrintWriter getWriter() { return null; }
+        @Override public void setCharacterEncoding(String charset) {}
+        @Override public void setContentLength(int len) {}
+        @Override public void setContentLengthLong(long len) {}
+        @Override public void setContentType(String type) {}
+        @Override public void setBufferSize(int size) {}
+        @Override public int getBufferSize() { return 0; }
+        @Override public void flushBuffer() {}
+        @Override public void resetBuffer() {}
+        @Override public boolean isCommitted() { return false; }
+        @Override public void reset() {}
+        @Override public void setLocale(Locale loc) {}
+        @Override public Locale getLocale() { return Locale.getDefault(); }
+    }
+}

--- a/src/test/java/com/frankies/bootcamp/service/OnboardingStateServiceTest.java
+++ b/src/test/java/com/frankies/bootcamp/service/OnboardingStateServiceTest.java
@@ -1,0 +1,65 @@
+package com.frankies.bootcamp.service;
+
+import com.frankies.bootcamp.model.AuthenticatedUser;
+import com.frankies.bootcamp.model.BootcampAthlete;
+import com.frankies.bootcamp.model.OnboardingState;
+import com.frankies.bootcamp.model.OnboardingStatus;
+import org.junit.jupiter.api.Test;
+
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OnboardingStateServiceTest {
+
+    @Test
+    void resolveReturnsStravaPendingWhenNoLinkedAthleteExists() throws SQLException {
+        OnboardingStateService service = new OnboardingStateService(athleteId -> false);
+
+        OnboardingStatus status = service.resolve(user("usr-1"), null);
+
+        assertEquals(OnboardingState.STRAVA_PENDING, status.getState());
+        assertTrue(status.isAppUserReady());
+        assertFalse(status.isStravaLinked());
+        assertFalse(status.hasCompetitionMembership());
+    }
+
+    @Test
+    void resolveReturnsCompetitionPendingWhenStravaLinkedWithoutMembership() throws SQLException {
+        OnboardingStateService service = new OnboardingStateService(athleteId -> false);
+
+        OnboardingStatus status = service.resolve(user("usr-1"), athlete("12345"));
+
+        assertEquals(OnboardingState.COMPETITION_PENDING, status.getState());
+        assertTrue(status.isStravaLinked());
+        assertFalse(status.hasCompetitionMembership());
+    }
+
+    @Test
+    void resolveReturnsReadyWhenStravaLinkedWithCompetitionMembership() throws SQLException {
+        OnboardingStateService service = new OnboardingStateService(athleteId -> true);
+
+        OnboardingStatus status = service.resolve(user("usr-1"), athlete("12345"));
+
+        assertEquals(OnboardingState.READY, status.getState());
+        assertTrue(status.isStravaLinked());
+        assertTrue(status.hasCompetitionMembership());
+    }
+
+    private static AuthenticatedUser user(String userId) {
+        AuthenticatedUser user = new AuthenticatedUser();
+        user.setUserId(userId);
+        user.setEmail("athlete@example.com");
+        user.setDisplayName("Athlete Example");
+        return user;
+    }
+
+    private static BootcampAthlete athlete(String athleteId) {
+        BootcampAthlete athlete = new BootcampAthlete();
+        athlete.setId(athleteId);
+        athlete.setEmail("athlete@example.com");
+        return athlete;
+    }
+}

--- a/src/test/java/com/frankies/bootcamp/service/PersistentActivityProcessServiceTest.java
+++ b/src/test/java/com/frankies/bootcamp/service/PersistentActivityProcessServiceTest.java
@@ -265,8 +265,15 @@ class PersistentActivityProcessServiceTest {
         }
 
         @Override
-        protected long ensureCompetitionAthlete(BootcampAthlete athlete) {
-            return fakeDbService.ensureCompetitionAthlete(athlete.getId(), athlete.getGoal());
+        protected Long getActiveCompetitionAthleteId(BootcampAthlete athlete) {
+            return fakeDbService.hasActiveCompetitionMembership(athlete.getId())
+                    ? fakeDbService.ensureCompetitionAthlete(athlete.getId(), athlete.getGoal())
+                    : null;
+        }
+
+        @Override
+        protected boolean hasActiveCompetitionMembership(String athleteId) {
+            return fakeDbService.hasActiveCompetitionMembership(athleteId);
         }
 
         @Override
@@ -416,6 +423,10 @@ class PersistentActivityProcessServiceTest {
         public long ensureCompetitionAthlete(String athleteId, Double startingGoal) {
             athleteIdsByCompetitionAthleteId.put(1L, athleteId);
             return 1L;
+        }
+
+        public boolean hasActiveCompetitionMembership(String athleteId) {
+            return athletesByStravaId.containsKey(athleteId);
         }
 
         public void replacePersistentCompetitionState(long competitionAthleteId,


### PR DESCRIPTION
## Summary
 - add explicit onboarding states for post-auth app routing
 - route linked-but-not-in-competition users to a competition onboarding holding page
 - preserve server-controlled Strava onboarding through BootcampServlet
 - add focused tests for onboarding state resolution and join-path auth filtering
 
 ## Included behavior
 - STRAVA_PENDING
 - COMPETITION_PENDING
 - READY
 
 ## Notes
 - this is the onboarding-state/routing slice for FBC-12
 - real competition join/create flows are still expected to land in follow-up multicomp tickets
