### PR TITLE
Fix session persistence timeout

### DIFF
--- a/src/main/java/com/frankies/bootcamp/service/AuthSessionService.java
+++ b/src/main/java/com/frankies/bootcamp/service/AuthSessionService.java
@@ -9,6 +9,7 @@ import jakarta.servlet.http.HttpSession;
 @ApplicationScoped
 public class AuthSessionService {
     public static final String AUTH_USER_SESSION_KEY = "authUser";
+    private static final int DEFAULT_SESSION_TIMEOUT_SECONDS = 60 * 60 * 24 * 30;
 
     public AuthenticatedUser getAuthenticatedUser(HttpServletRequest request) {
         HttpSession session = request.getSession(false);
@@ -24,6 +25,7 @@ public class AuthSessionService {
 
     public void storeAuthenticatedUser(HttpServletRequest request, AuthenticatedUser user, BootcampAthlete athlete) {
         HttpSession session = request.getSession(true);
+        session.setMaxInactiveInterval(DEFAULT_SESSION_TIMEOUT_SECONDS);
         session.setAttribute(AUTH_USER_SESSION_KEY, user);
         session.setAttribute("athlete", athlete);
         session.setAttribute("athleteEmail", user.getEmail());

--- a/src/test/java/com/frankies/bootcamp/auth/AuthSessionServiceTest.java
+++ b/src/test/java/com/frankies/bootcamp/auth/AuthSessionServiceTest.java
@@ -3,6 +3,7 @@ package com.frankies.bootcamp.auth;
 import com.frankies.bootcamp.model.AuthenticatedUser;
 import com.frankies.bootcamp.model.BootcampAthlete;
 import com.frankies.bootcamp.service.AuthSessionService;
+import com.frankies.bootcamp.servlet.JoinServlet;
 import com.frankies.bootcamp.servlet.LoginServlet;
 import jakarta.servlet.ServletConnection;
 import jakarta.servlet.ServletContext;
@@ -51,6 +52,7 @@ class AuthSessionServiceTest {
         assertSame(athlete, request.session.getAttribute("athlete"));
         assertEquals("athlete@example.com", request.session.getAttribute("athleteEmail"));
         assertEquals("Athlete Example", request.session.getAttribute("athleteName"));
+        assertEquals(60 * 60 * 24 * 30, request.session.maxInactiveInterval);
     }
 
     @Test
@@ -79,7 +81,7 @@ class AuthSessionServiceTest {
 
         servlet.handleGet(request, response);
 
-        assertEquals("/bootcamp/auth/external/login", response.redirectedTo);
+        assertEquals("/bootcamp/auth/external/login?prompt=login", response.redirectedTo);
     }
 
     @Test
@@ -91,10 +93,27 @@ class AuthSessionServiceTest {
 
         servlet.handleGet(request, response);
 
-        assertEquals("/bootcamp/auth/external/login?error=external+failure", response.redirectedTo);
+        assertEquals("/bootcamp/auth/external/login?prompt=login&error=external+failure", response.redirectedTo);
+    }
+
+    @Test
+    void joinServletRedirectsStraightToExternalLoginWithPrompt() throws Exception {
+        TestableJoinServlet servlet = new TestableJoinServlet();
+        FakeHttpServletRequest request = new FakeHttpServletRequest("/bootcamp", new FakeHttpSession());
+        FakeHttpServletResponse response = new FakeHttpServletResponse();
+
+        servlet.handleGet(request, response);
+
+        assertEquals("/bootcamp/auth/external/login?prompt=login", response.redirectedTo);
     }
 
     private static final class TestableLoginServlet extends LoginServlet {
+        void handleGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+            super.doGet(request, response);
+        }
+    }
+
+    private static final class TestableJoinServlet extends JoinServlet {
         void handleGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
             super.doGet(request, response);
         }
@@ -353,6 +372,7 @@ class AuthSessionServiceTest {
     private static final class FakeHttpSession implements HttpSession, Serializable {
         private final Map<String, Object> attributes = new HashMap<>();
         private boolean invalidated;
+        private int maxInactiveInterval;
 
         @Override
         public long getCreationTime() { return 0; }
@@ -363,9 +383,9 @@ class AuthSessionServiceTest {
         @Override
         public ServletContext getServletContext() { return null; }
         @Override
-        public void setMaxInactiveInterval(int interval) {}
+        public void setMaxInactiveInterval(int interval) { this.maxInactiveInterval = interval; }
         @Override
-        public int getMaxInactiveInterval() { return 0; }
+        public int getMaxInactiveInterval() { return maxInactiveInterval; }
         @Override
         public Object getAttribute(String name) { return attributes.get(name); }
         public Object getValue(String name) { return getAttribute(name); }


### PR DESCRIPTION
 ## Summary
 - keep authenticated app sessions alive for 30 days of inactivity
 - stop users being forced to log in again between normal uses
 - add/update auth session test coverage for the configured timeout
 
 ## Notes
 - this changes app session lifetime, not Auth0's own SSO/token lifetime
 - logout and switch-user behavior remain the same
