### PR TITLE
Preserve active dashboard tab on refresh

### DIFF
--- a/.copilotignore
+++ b/.copilotignore
@@ -1,0 +1,21 @@
+# Build outputs
+target/
+**/target/
+*.class
+*.jar
+*.war
+*.ear
+
+# IDE / repo metadata
+.git/
+.idea/
+
+# Logs
+logs/
+*.log
+
+# Node / frontend generated files, if any
+node_modules/
+dist/
+build/
+out/

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,6 +4,7 @@
 - Apply `.copilotignore` before reading or indexing repo files.
 - Run `copilot-byok.ps1` from the repo root when local Copilot BYOK, Jira, Confluence, or Maven setup is needed.
 - Read `SESSION_HANDOFF.md`, `BACKLOG_GROOMING_HANDOFF.md`, `CONTEXT.md`, `AGENTS.md`, and the relevant `docs\agents\*.md` files before changing behavior or workflow-sensitive code.
+- For Jira work, the project key is `FBC`; read `docs\agents\issue-tracker.md` before creating, reprioritizing, or closing work.
 - Add or update a short ADR under `docs\adr\` when a change affects persistence shape, authorization boundaries, or long-term architecture.
 
 ## Build, test, and lint
@@ -13,13 +14,13 @@
   - `mvn -Dtest=ClassName test`
   - `mvn -Dtest=ClassName#methodName test`
   - `mvn package`
+- `mvnw.cmd` exists, but `.mvn\wrapper\maven-wrapper.properties` is missing, so use Maven directly.
 - Useful single-test examples:
   - `mvn -Dtest=AuthSessionServiceTest test`
   - `mvn -Dtest=ActivityProcessServiceTest test`
   - `mvn -Dtest=PersistentActivityProcessServiceTest test`
   - `mvn -Dtest=PerformanceFixtureLoadingTest test`
 - Tests live under `src\test\java\com\frankies\bootcamp\...`.
-- `mvnw.cmd` exists, but `.mvn\wrapper\maven-wrapper.properties` is missing, so use Maven directly.
 - There is no dedicated lint command in `pom.xml`.
 
 ## High-level architecture
@@ -36,6 +37,7 @@
 
 ## Key conventions
 - Use the repo vocabulary from `CONTEXT.md`: athlete, user, competition, competition membership, global roles, competition roles, All Sports Equal, normalized activities, derived stats, and DB-backed summary.
+- Prefer the glossary terms from `docs\agents\domain.md` when naming issues, tests, ADRs, or implementation concepts.
 - Prefer `competition_athlete` for the athlete-in-competition row/table name.
 - Keep `competition_activity_detail` thin; it should only hold the fields needed for current `stravaActivityDetails` behavior.
 - Persistent rebuilds are scoped to one `competition_athlete` at a time and should delete/recreate derived rows for that scope.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,14 +1,12 @@
 # Copilot instructions for Frankie's Bootcamp
 
 ## Read first
-0
 - Apply `.copilotignore` before reading or indexing repo files.
 - Run `copilot-byok.ps1` from the repo root when local Copilot BYOK, Jira, Confluence, or Maven setup is needed.
 - Read `SESSION_HANDOFF.md`, `BACKLOG_GROOMING_HANDOFF.md`, `CONTEXT.md`, `AGENTS.md`, and the relevant `docs\agents\*.md` files before changing behavior or workflow-sensitive code.
 - Add or update a short ADR under `docs\adr\` when a change affects persistence shape, authorization boundaries, or long-term architecture.
 
 ## Build, test, and lint
-
 - Maven WAR project targeting Java 23 and a Jakarta EE / WildFly-style runtime.
 - Run from the repo root with Maven:
   - `mvn test`
@@ -25,24 +23,23 @@
 - There is no dedicated lint command in `pom.xml`.
 
 ## High-level architecture
-
-- Server-rendered Jakarta web app packaged as a WAR. Main UI is JSP-based under `src\main\webapp`, with servlet endpoints under `src\main\java\com\frankies\bootcamp\servlet`.
-- `/app` maps to `AppServlet`, which forwards to `src\main\webapp\app\index.jsp`. That dashboard is intentionally server-rendered and eagerly includes tab content.
-- `/api` is a small JAX-RS layer under `src\main\java\com\frankies\bootcamp\rest` for Strava auth callback flow, athlete summary JSON, and the Strava webhook.
-- `AuthenticationFilter` protects most routes; `AuthSessionService` is the canonical place for reading and writing authenticated-user and athlete session state.
-- `BootcampServlet` centralizes authenticated-page gating, Strava onboarding, competition selection state, and onboarding forwarding. App servlets that need the current athlete should usually inherit from it.
-- `ActivityProcessFacade` switches between the legacy in-memory `ActivityProcessService` and the DB-backed `PersistentActivityProcessService` using `BOOTCAMP_ACTIVITY_MODE`. Summary, leaderboard, honour-roll, ZenBot, scheduled rebuild, and webhook changes need to account for both modes unless intentionally scoped to one.
-- `DBService` is both the JDBC layer and the current startup-DDL mechanism. It uses the JBoss datasource `java:jboss/strava` and creates the auth, audit, ZenBot, and competition tables at startup.
-- `StravaService` owns OAuth, token refresh, activity fetches, and single-activity lookup. `StravaWebhook` accepts webhook events quickly and processes activity changes asynchronously.
-- `TabAuditServlet` is the central place for dashboard audit writes; initial `/app/` landing and real tab clicks are treated differently.
+- Server-rendered Jakarta web app packaged as a WAR. JSPs live under `src\main\webapp`; annotated servlets live under `src\main\java\com\frankies\bootcamp\servlet`; REST endpoints live under `rest`; shared business logic lives in `service`.
+- `web.xml` only wires a few legacy JSP/page routes and the UTF-8 filter; most request handling is annotation-based.
+- `/app` is `AppServlet`, which forwards to `src\main\webapp\app\index.jsp`. The dashboard is intentionally server-rendered and eagerly includes tab content.
+- `BootcampServlet` is the main authenticated-page gate. It loads the current athlete, resolves onboarding state, syncs the selected competition, and forwards to the correct onboarding/chooser page before child servlets run.
+- `AuthenticationFilter` is the broad gate for public vs protected paths. It lets static assets and a small public route list through, redirects browser requests to `/login`, and returns 401 for unauthenticated `/api/*` calls.
+- `AuthSessionService` is the canonical source for session keys and semantics (`authUser`, `selectedCompetitionId`, pending invitation token).
+- `ActivityProcessFacade` switches between the legacy in-memory `ActivityProcessService` and the DB-backed `PersistentActivityProcessService` via `BOOTCAMP_ACTIVITY_MODE`.
+- `DBService` owns JDBC access and startup DDL against the `java:jboss/strava` datasource. The current persistence slice is competition-scoped and centered on `competition`, `competition_athlete`, `competition_activity_detail`, weekly stats, summary, and honour-roll tables.
+- `StravaService` owns OAuth, token refresh, activity fetches, and single-activity lookup. `StravaWebhook` accepts webhook events quickly and hands off processing.
+- `TabAuditServlet` is the central place for dashboard audit writes; the initial `/app/` landing and real tab clicks are tracked differently.
 
 ## Key conventions
-
 - Use the repo vocabulary from `CONTEXT.md`: athlete, user, competition, competition membership, global roles, competition roles, All Sports Equal, normalized activities, derived stats, and DB-backed summary.
 - Prefer `competition_athlete` for the athlete-in-competition row/table name.
 - Keep `competition_activity_detail` thin; it should only hold the fields needed for current `stravaActivityDetails` behavior.
 - Persistent rebuilds are scoped to one `competition_athlete` at a time and should delete/recreate derived rows for that scope.
-- Use `BootcampServlet` for authenticated JSP pages instead of duplicating auth/onboarding logic.
+- Reuse `BootcampServlet` for authenticated JSP pages instead of duplicating auth/onboarding logic.
 - Reuse `AuthSessionService` for session attribute names and semantics instead of inventing new keys.
 - Keep dashboard tab auditing centralized in `TabAuditServlet`; the `/app/` landing event and `history`, `leaderboard`, `honour-roll`, and `summary` clicks should not be conflated.
 - `PerformanceFixtureLoadingTest` uses raw Gson `JsonObject` / `JsonArray` because `stravaActivityDetails.sport` is typed as abstract `BaseSport`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,99 +1,51 @@
 # Copilot instructions for Frankie's Bootcamp
 
-## Session context files
+## Read first
+0
+- Apply `.copilotignore` before reading or indexing repo files.
+- Run `copilot-byok.ps1` from the repo root when local Copilot BYOK, Jira, Confluence, or Maven setup is needed.
+- Read `SESSION_HANDOFF.md`, `BACKLOG_GROOMING_HANDOFF.md`, `CONTEXT.md`, `AGENTS.md`, and the relevant `docs\agents\*.md` files before changing behavior or workflow-sensitive code.
+- Add or update a short ADR under `docs\adr\` when a change affects persistence shape, authorization boundaries, or long-term architecture.
 
-- Start new repo sessions by running `copilot-byok.ps1` from the repo root when local Copilot BYOK, Jira, Confluence, or Maven setup is needed.
-- Read `SESSION_HANDOFF.md` first for current implementation status, recent decisions, and active constraints.
-- Use `BACKLOG_GROOMING_HANDOFF.md` for ticket order, prompt shaping, and near-term sequencing.
-- Use `CONTEXT.md` for shared product and architecture vocabulary.
-- Read `AGENTS.md` and `docs\agents\*.md` when work touches issue tracking, triage flow, or domain-doc consumption rules.
-- When a change affects long-term structure or project direction, add or update a short ADR under `docs\adr\` using the format in `docs\adr\README.md`.
+## Build, test, and lint
 
-## Default working style
-
-- Keep answers about 50% shorter than default. Be direct and practical.
-- Prefer clear recommendations over long option lists.
-- Work one ticket at a time unless explicitly asked for a broader plan.
-- For each ticket, give the user:
-  1. a refined goal
-  2. a pasteable ticket prompt
-  3. suggested ordering/dependencies
-  4. key risks and scope boundaries
-- Flag tickets that should be renamed, split, or moved in order.
-- If a ticket changed in Jira or the handoff files since the last local prompt, re-check the current ticket meaning before implementing.
-
-## Agent and tracker docs
-
-- `AGENTS.md` is the short entrypoint for repo-specific skill configuration.
-- `docs\agents\issue-tracker.md` defines the Jira-based tracker workflow and current local tracker notes.
-- `docs\agents\triage-labels.md` defines the label vocabulary used by triage-style skills.
-- `docs\agents\domain.md` tells skills how to consume `CONTEXT.md` and ADRs.
-- When implementation or backlog discussions change tracker reality, update the relevant tracker docs along with `SESSION_HANDOFF.md` and `BACKLOG_GROOMING_HANDOFF.md`.
-
-## Build, test, and lint commands
-
-- This is a Maven WAR project targeting Java 23 and a Jakarta EE / WildFly-style runtime.
-- Run commands from the repo root with Maven directly:
+- Maven WAR project targeting Java 23 and a Jakarta EE / WildFly-style runtime.
+- Run from the repo root with Maven:
   - `mvn test`
   - `mvn -Dtest=ClassName test`
   - `mvn -Dtest=ClassName#methodName test`
   - `mvn package`
-- Current tests are plain JUnit 5 tests under `src\test\java\com\frankies\bootcamp\...`.
-- Useful current single-test examples:
+- Useful single-test examples:
   - `mvn -Dtest=AuthSessionServiceTest test`
   - `mvn -Dtest=ActivityProcessServiceTest test`
   - `mvn -Dtest=PersistentActivityProcessServiceTest test`
   - `mvn -Dtest=PerformanceFixtureLoadingTest test`
-- `mvnw.cmd` exists, but do not rely on the Maven wrapper: `.mvn\wrapper\maven-wrapper.properties` is missing.
+- Tests live under `src\test\java\com\frankies\bootcamp\...`.
+- `mvnw.cmd` exists, but `.mvn\wrapper\maven-wrapper.properties` is missing, so use Maven directly.
 - There is no dedicated lint command in `pom.xml`.
 
 ## High-level architecture
 
-- The app is primarily a server-rendered Jakarta web application packaged as a WAR. The main user-facing flow is JSP-based under `src\main\webapp`, with servlet endpoints under `src\main\java\com\frankies\bootcamp\servlet`.
-- The authenticated app entrypoint is `/app` via `AppServlet`, which forwards to `src\main\webapp\app\index.jsp`. That dashboard is intentionally server-rendered and eagerly includes the History, Honour Roll, Leaderboard, and Summary tab content through backing servlets.
-- There is also a small JAX-RS layer under `src\main\java\com\frankies\bootcamp\rest` mounted at `/api`. It handles Strava auth callback flow, athlete summary JSON endpoints, and the Strava webhook.
-- Authentication is session-based. `AuthenticationFilter` protects most routes, allows a small public path list, and can bootstrap a session from ngrok-provided auth headers. `AuthSessionService` is the canonical place for reading and writing the authenticated user plus cached athlete session attributes.
-- `BootcampServlet` is the base servlet for authenticated app pages. It resolves the signed-in `AuthenticatedUser`, loads the linked `BootcampAthlete`, and forwards users without a completed Strava link into the server-controlled Strava onboarding JSP. App servlets that need the current athlete usually inherit from this class rather than reimplementing auth checks.
-- Activity and leaderboard behavior currently flow through `ActivityProcessFacade`, which switches between the legacy in-memory `ActivityProcessService` and the newer `PersistentActivityProcessService` based on `BOOTCAMP_ACTIVITY_MODE`. Changes to summary, leaderboard, honour-roll, ZenBot stats context, scheduled rebuilds, or webhook behavior need to account for both modes unless the task explicitly removes one.
-- The legacy path still builds a large in-memory summary model in `ActivityProcessService`. It fetches athletes from `DBService`, pulls Strava activities through `StravaService`, converts them into `BaseSport` implementations through `SportFactory`, and assembles `PerformanceResponse` / `WeeklyPerformance` outputs.
-- The persistent path uses `PersistentActivityProcessService` plus `DBService` to rebuild one athlete at a time, store thin `competition_activity_detail` rows plus derived weekly and summary tables, and then serve leaderboard and honour-roll reads from DB-backed read models.
-- `DBService` is both the JDBC access layer and the current schema-management mechanism. It looks up the JBoss datasource `java:jboss/strava`, performs startup DDL for auth, audit, ZenBot, and competition-derived persistence tables, and owns most database read/write operations. There is no separate migration framework yet.
-- `ActivityProcessJob` triggers summary rebuilding on startup and daily, delegating through `ActivityProcessFacade` so scheduled processing follows the active mode.
-- Strava integration is centered in `StravaService`: callback URL construction, OAuth token exchange, token refresh, activity fetches, and single-activity retrieval for webhook handling. `AuthResource` keeps Strava link initiation and callback handling server-controlled.
-- `StravaWebhook` acknowledges webhook requests quickly and processes create/update/delete events asynchronously, routing activity mutations through `ActivityProcessFacade`.
-- ZenBot is a server-side feature for logged-in athletes. `ZenBotServlet` combines `AiMessageService`, athlete-specific stats context from the activity processing layer, and persisted conversation history in `zenbot_messages`.
+- Server-rendered Jakarta web app packaged as a WAR. Main UI is JSP-based under `src\main\webapp`, with servlet endpoints under `src\main\java\com\frankies\bootcamp\servlet`.
+- `/app` maps to `AppServlet`, which forwards to `src\main\webapp\app\index.jsp`. That dashboard is intentionally server-rendered and eagerly includes tab content.
+- `/api` is a small JAX-RS layer under `src\main\java\com\frankies\bootcamp\rest` for Strava auth callback flow, athlete summary JSON, and the Strava webhook.
+- `AuthenticationFilter` protects most routes; `AuthSessionService` is the canonical place for reading and writing authenticated-user and athlete session state.
+- `BootcampServlet` centralizes authenticated-page gating, Strava onboarding, competition selection state, and onboarding forwarding. App servlets that need the current athlete should usually inherit from it.
+- `ActivityProcessFacade` switches between the legacy in-memory `ActivityProcessService` and the DB-backed `PersistentActivityProcessService` using `BOOTCAMP_ACTIVITY_MODE`. Summary, leaderboard, honour-roll, ZenBot, scheduled rebuild, and webhook changes need to account for both modes unless intentionally scoped to one.
+- `DBService` is both the JDBC layer and the current startup-DDL mechanism. It uses the JBoss datasource `java:jboss/strava` and creates the auth, audit, ZenBot, and competition tables at startup.
+- `StravaService` owns OAuth, token refresh, activity fetches, and single-activity lookup. `StravaWebhook` accepts webhook events quickly and processes activity changes asynchronously.
+- `TabAuditServlet` is the central place for dashboard audit writes; initial `/app/` landing and real tab clicks are treated differently.
 
 ## Key conventions
 
 - Use the repo vocabulary from `CONTEXT.md`: athlete, user, competition, competition membership, global roles, competition roles, All Sports Equal, normalized activities, derived stats, and DB-backed summary.
-- Preserve the current strategic direction captured in the handoff files: replace the large in-memory summary with DB-backed activity/stat handling, then move toward explicit competition membership and competition-scoped authorization.
-- For the current persistence design, prefer the clearer storage term `competition_athlete` for the athlete-in-competition relation.
-- The current preferred `FBC-22` model is competition-scoped and uses `competitions`, `competition_athlete`, `competition_activity_detail`, `competition_weekly_stats`, `competition_weekly_sport_stats`, `competition_summary`, `competition_summary_sport_stats`, and `competition_honour_roll`.
-- `competition_activity_detail` is intentionally thin and should keep only the fields needed for the current `stravaActivityDetails` behavior so webhook add, update, and delete remain possible without mirroring the full Strava payload.
-- Rebuilds in the persistent path should be scoped to one `competition_athlete` at a time and should delete and recreate derived rows for that scope.
-- Keep dashboard tab auditing centralized in `TabAuditServlet`. Initial `/app/` render should record one `page-landing` event, and tab audit writes for `history`, `leaderboard`, `honour-roll`, and `summary` should only happen on real user clicks.
-- Treat the current dashboard loading approach as intentional. `src\main\webapp\app\index.jsp` eagerly includes tab content, and previous lazy-loading attempts caused regressions.
-- Preserve server-side gating for Strava onboarding and ZenBot. Users without a linked Strava athlete should be routed through the onboarding flow by `BootcampServlet`, not by ad hoc page logic.
-- Follow the existing package split: `servlet` for JSP-backed HTTP endpoints, `rest` for JAX-RS APIs, `service` for orchestration and integration code, `model` for app and API payload models, `sport` for sport-specific scoring behavior, `filter` for request filters, and `job` for scheduled refresh work.
-- Reuse `AuthSessionService` for session attribute names and semantics instead of setting custom auth or session keys ad hoc.
-- Be careful with tests that load the sanitized performance fixtures. `PerformanceFixtureLoadingTest` asserts against raw Gson `JsonObject` / `JsonArray` rather than deserializing into `PerformanceResponse` because `stravaActivityDetails.sport` is typed as abstract `BaseSport`.
-- `PersistentActivityProcessServiceTest` uses small protected test seams in the persistent service and fake DB/Strava collaborators instead of requiring a JNDI datasource; follow that pattern for persistent-service unit coverage.
+- Prefer `competition_athlete` for the athlete-in-competition row/table name.
+- Keep `competition_activity_detail` thin; it should only hold the fields needed for current `stravaActivityDetails` behavior.
+- Persistent rebuilds are scoped to one `competition_athlete` at a time and should delete/recreate derived rows for that scope.
+- Use `BootcampServlet` for authenticated JSP pages instead of duplicating auth/onboarding logic.
+- Reuse `AuthSessionService` for session attribute names and semantics instead of inventing new keys.
+- Keep dashboard tab auditing centralized in `TabAuditServlet`; the `/app/` landing event and `history`, `leaderboard`, `honour-roll`, and `summary` clicks should not be conflated.
+- `PerformanceFixtureLoadingTest` uses raw Gson `JsonObject` / `JsonArray` because `stravaActivityDetails.sport` is typed as abstract `BaseSport`.
+- `PersistentActivityProcessServiceTest` uses protected test seams and fake DB/Strava collaborators instead of a real JNDI datasource.
 - Be aware of the known bug candidate in `ActivityProcessService.ensureWeeksUpTo(...)` around `get(w - 2)` when later weeks are created.
-- Do not commit or copy secrets from repository files. There is a known unsafe credential file at `src\main\resources\credentials.json`.
-
-## Repo workflow files
-
-- `copilot-byok.ps1` bootstraps local Copilot BYOK and Atlassian-related environment variables.
-- `SESSION_HANDOFF.md`, `BACKLOG_GROOMING_HANDOFF.md`, and `CONTEXT.md` are part of the intended working pattern for this repo and should be kept in sync with major changes.
-- `AGENTS.md` and `docs\agents\*.md` hold the Matt Pocock skill configuration for this repo and should stay aligned with the actual Jira workflow, triage labels, and domain-doc layout.
-
-## Startup shortcut
-
-For a fresh session in this repo, the expected order is:
-
-1. Run `copilot-byok.ps1` if local env/bootstrap is needed.
-2. Read `SESSION_HANDOFF.md`.
-3. Read `BACKLOG_GROOMING_HANDOFF.md`.
-4. Read `CONTEXT.md`.
-5. Read `.github\copilot-instructions.md`.
-6. Read `AGENTS.md` plus relevant `docs\agents\*.md` files when tracker/skill behavior matters.
+- Do not commit or copy secrets from repository files; `src\main\resources\credentials.json` is known unsafe.

--- a/BACKLOG_GROOMING_HANDOFF.md
+++ b/BACKLOG_GROOMING_HANDOFF.md
@@ -67,15 +67,17 @@ A "dev ready" top-of-board order was established to prioritize:
   - Leaving/removing yourself from a competition is intentionally deferred to `FBC-89` for membership lifecycle and `FBC-54` for authorization rules.
 - Current local follow-up branch:
   - `feature/fbc-insights-tab` was created from the FBC-30 feature branch after the multi-active competition stale rebuild fix was committed and pushed to PR #16 as `4b3462c`.
-  - This branch is uncommitted local work for a read-only dashboard Insights tab, not yet assigned to a Jira ticket in this handoff. PR should target `feature/fbc-30-competition-selection`, because this is stacked on PR #16.
+  - This branch is pushed local work for a read-only dashboard Insights tab, not yet assigned to a Jira ticket in this handoff. PR should target `feature/fbc-30-competition-selection`, because this is stacked on PR #16.
   - Implemented local scope:
     - final dashboard tab `/app/Insights`
     - athlete profile modal for any athlete in the selected competition
     - compact dropdown for choosing another athlete profile
     - global Profile card on athlete profiles, with accepted blurbs persisted as verified and unaccepted generated text lazily regenerated after render
     - clearing the Profile box and saving deletes the verified profile, returning that athlete to generated/unverified mode
+    - accepted/verified profiles disable `Save changes` until the text is edited
     - generated current Performance summary at the bottom of the profile modal
     - Strava-link-time storage of `athletes.sex`, used for AI pronouns when present; otherwise prompts stay generic and do not guess gender from names
+    - active dashboard tab is stored in the URL as `?tab=...`, so pull-to-refresh restores the selected tab instead of defaulting to Weekly History
     - position-over-time graph showing overall leaderboard rank history
     - current/latest completed week is shown on the left; history runs rightward back to Week 1
     - tied leaderboard scores share the same rank rather than inventing order
@@ -91,7 +93,7 @@ A "dev ready" top-of-board order was established to prioritize:
     - `getLoggedInAthleteSummary(...)` and `getLoggedInAthleteSummaryForCompetition(...)` now use cumulative sport totals from `competition_summary_sport_stats`, restoring old `PerformanceResponse.toString()` behavior.
   - Current validation:
     - targeted service tests are green, including `CompetitionInsightsServiceTest` and `PersistentActivityProcessServiceTest`
-    - full `mvn package` is green after the latest graph/UI/profile-summary/Strava-sex tweaks
+    - full `mvn package` is green after the latest graph/UI/profile-summary/Strava-sex/tab-refresh tweaks
   - This probably deserves its own Jira ticket if it is kept separate from FBC-30 rather than folded into the PR.
 
 ## Agreed current board order

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -12,18 +12,21 @@ New way of working
 
 ## Current state
 
-The latest completed work finished `FBC-16` and then completed and browser-tested `FBC-30` on `feature/fbc-30-competition-selection`. PR #16 is open and the user is moving `FBC-30` to code review. The repo now supports explicit multi-competition selection, historical competition browsing, competition-scoped sick weeks, and bounded/backgrounded historical rebuilds.
+The latest completed work finished the competition invitation flow and the related profile/avatar hardening on `security-hardening-invites-avatar`. The repo now supports DB-backed competition invitations, invite links that survive signup/login/onboarding, dashboard invite CTAs, bulk invites, and stored-avatar-first profile rendering.
 
-### Current local branch after FBC-30: Insights tab work
+### Current local branch after competition invites and profile hardening
 
-- Current branch: `feature/fbc-insights-tab`.
-- This branch was created from `feature/fbc-30-competition-selection` after committing and pushing the FBC-30 follow-up fix `4b3462c Fix multi-competition active rebuilds`.
-- Pushed branch work adds a new read-only dashboard **Insights** tab using existing derived data. Open it as a PR **into `feature/fbc-30-competition-selection`**, because this branch is stacked on the FBC-30 PR.
-- The older local FBC-89 handoff/tracker notes are still intentionally uncommitted unless the user later asks to commit them.
-- Full `mvn package` is green after the final tab-refresh/profile tweaks. Targeted tests have also been run repeatedly and are green:
-  - `mvn "-Dtest=CompetitionInsightsServiceTest" test`
-  - `mvn "-Dtest=PersistentActivityProcessServiceTest,CompetitionInsightsServiceTest" test`
-  - `mvn package`
+- Current branch: `security-hardening-invites-avatar`.
+- HEAD is `ca4b465`, with local edits still in the worktree for the avatar-precedence fix and handoff updates.
+- Completed on this branch:
+  - competition invitations by email
+  - bulk invite entry with comma/newline/semicolon parsing
+  - existing-athlete search on the invite form
+  - invite accept/decline and dashboard invite CTAs
+  - public invite links that survive login and Strava onboarding
+  - temporary allowlist gating for create/join competition access
+  - stored-avatar-first profile rendering for the insights/profile modal
+- Current local validation: `mvn -q -DskipTests compile` is green.
 
 #### Insights tab implemented behavior
 

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -18,9 +18,9 @@ The latest completed work finished `FBC-16` and then completed and browser-teste
 
 - Current branch: `feature/fbc-insights-tab`.
 - This branch was created from `feature/fbc-30-competition-selection` after committing and pushing the FBC-30 follow-up fix `4b3462c Fix multi-competition active rebuilds`.
-- Local uncommitted branch work adds a new read-only dashboard **Insights** tab using existing derived data. It should be opened as a PR **into `feature/fbc-30-competition-selection`**, because this branch is stacked on the FBC-30 PR.
+- Pushed branch work adds a new read-only dashboard **Insights** tab using existing derived data. Open it as a PR **into `feature/fbc-30-competition-selection`**, because this branch is stacked on the FBC-30 PR.
 - The older local FBC-89 handoff/tracker notes are still intentionally uncommitted unless the user later asks to commit them.
-- Full `mvn package` is green after the final Strava-sex/profile-copy tweaks. Targeted tests have also been run repeatedly and are green:
+- Full `mvn package` is green after the final tab-refresh/profile tweaks. Targeted tests have also been run repeatedly and are green:
   - `mvn "-Dtest=CompetitionInsightsServiceTest" test`
   - `mvn "-Dtest=PersistentActivityProcessServiceTest,CompetitionInsightsServiceTest" test`
   - `mvn package`
@@ -39,11 +39,13 @@ The latest completed work finished `FBC-16` and then completed and browser-teste
   - the logged-in athlete can edit the text and `Accept and save`, which persists it as `Verified` for everyone
   - unaccepted generated text is intentionally not stored globally
   - clearing the profile box and saving deletes the verified row, so the profile returns to generated/unverified mode
+  - accepted/verified profiles show an inactive `Save changes` button until the text is edited
   - the generated Profile text is timeless/personal, not a current competition update
 - Profiles also include a separate generated **Performance summary** at the bottom that uses current selected-competition points/rank context, including the current week, but still avoids private km values.
 - Strava `sex` is stored on `athletes.sex` when an athlete links Strava. AI profile/performance prompts use it for pronouns when present (`M`/`F`); otherwise they stay generic and must not guess gender from names.
 - Athlete names in Leaderboard and Honour Roll open the profile modal when the dashboard has loaded the Insights include.
 - Names are intentionally **not** clickable in Insights "Week-by-week leaderboard winners" or "Sport-specific standings".
+- Dashboard tab state is stored in the URL as `?tab=history|leaderboard|honour-roll|summary|insights`, so pull-to-refresh restores the currently selected tab instead of defaulting to Weekly History.
 - `InsightsServlet` deliberately does **not** close `response.getWriter()` and no longer prints nested `<html>` / `<body>` markup, because it is rendered through `<jsp:include>` inside `index.jsp`. Closing the included writer caused WildFly/Jasper `JBWEB004052: Exception occurred when flushing data` logs while the page still appeared to work.
 
 #### Insights privacy / scoring decisions

--- a/copilot-byok.ps1
+++ b/copilot-byok.ps1
@@ -5,8 +5,8 @@
 # Editable non-secret defaults
 $defaultCopilotProviderType = "openai"
 $defaultCopilotProviderBaseUrl = "https://api.openai.com/v1"
-$defaultCopilotProviderModelId = "gpt-5.4"
-$defaultCopilotProviderWireModel = "gpt-5.5"
+$defaultCopilotProviderModelId = "gpt-5.4-mini"
+$defaultCopilotProviderWireModel = "gpt-5.4-mini"
 $defaultCopilotProviderWireApi = "responses"
 $defaultMavenBinPath = "C:\TFS\apache-maven-3.9.16-bin\apache-maven-3.9.16\bin"
 $defaultAtlassianBaseUrl = "https://millses.atlassian.net"

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -50,15 +50,16 @@ Issues and PRDs for this repo live in Jira. Use the Atlassian Jira CLI workflow 
       - competition-scoped sick weeks are now stored under `competition_athlete_sick_week`; completed competitions cannot be edited through the history UI
       - incomplete historical competitions trigger bounded background rebuilds, then freeze once persisted state is complete and the comp is older than 14 days
       - self-removal/leaving a competition is intentionally not part of `FBC-30`; track that membership lifecycle under `FBC-89`, with authorization constraints in `FBC-54`
-  - Latest local follow-up status: a separate uncommitted local branch `feature/fbc-insights-tab` now exists for a read-only dashboard Insights tab built from existing derived data. It should be reviewed as a stacked PR targeting `feature/fbc-30-competition-selection`.
+  - Latest local follow-up status: a separate pushed branch `feature/fbc-insights-tab` now exists for a read-only dashboard Insights tab built from existing derived data. It should be reviewed as a stacked PR targeting `feature/fbc-30-competition-selection`.
     - It adds athlete profile modals, a compact profile dropdown, position-over-time leaderboard rank graph, week-by-week winner summaries, and sport-specific standings.
-    - Athlete profiles now include a global Profile card; accepted blurbs persist as verified, while unaccepted generated text is not stored and regenerates lazily after render. Clearing and saving the Profile deletes the verified row.
+    - Athlete profiles now include a global Profile card; accepted blurbs persist as verified, while unaccepted generated text is not stored and regenerates lazily after render. Clearing and saving the Profile deletes the verified row, and accepted profiles disable `Save changes` until edited.
     - Profiles also include a current generated Performance summary, and Strava-link-time `athletes.sex` is used for pronouns when present without guessing from names.
+    - Dashboard tab state is stored in the URL as `?tab=...`, so pull-to-refresh keeps the current tab.
     - Privacy rule: do not expose public athlete-level km values in Insights; Honour Roll distance values were also hidden locally and now show the distance leader name only.
     - Active competitions exclude the current partial week from Insights.
     - Tied leaderboard scores share the same rank in the position graph.
     - Persistent summary text was fixed locally to use cumulative sport totals from `competition_summary_sport_stats`.
-    - Targeted tests and full `mvn package` are green after the latest UI/profile-summary tweaks.
+    - Targeted tests and full `mvn package` are green after the latest UI/profile-summary/tab-refresh tweaks.
     - If this work is not folded into `FBC-30`, create/assign a Jira ticket before committing/pushing.
 
 ## Conventions

--- a/src/main/java/com/frankies/bootcamp/filter/AuthenticationFilter.java
+++ b/src/main/java/com/frankies/bootcamp/filter/AuthenticationFilter.java
@@ -16,7 +16,7 @@ import java.util.Set;
 public class AuthenticationFilter implements Filter {
     private static final Set<String> PUBLIC_PATHS = Set.of(
             "/", "/index.jsp", "/privacy", "/privacy.jsp", "/terms", "/terms.jsp", "/scoring", "/scoring.jsp",
-            "/login", "/logout", "/join", "/join.jsp", "/error.jsp", "/api/strava/webhook",
+            "/login", "/logout", "/join", "/join.jsp", "/invite", "/error.jsp", "/api/strava/webhook",
             "/auth/external/login", "/auth/external/callback", "/app/whoami.jsp"
     );
 

--- a/src/main/java/com/frankies/bootcamp/job/ActivityProcessJob.java
+++ b/src/main/java/com/frankies/bootcamp/job/ActivityProcessJob.java
@@ -1,7 +1,6 @@
 package com.frankies.bootcamp.job;
 
 import com.frankies.bootcamp.service.ActivityProcessFacade;
-import jakarta.annotation.PostConstruct;
 import jakarta.ejb.Asynchronous;
 import jakarta.ejb.Schedule;
 import jakarta.ejb.Singleton;
@@ -17,12 +16,6 @@ public class ActivityProcessJob {
 
     @Inject
     ActivityProcessFacade activityProcessFacade;
-
-    @PostConstruct
-    public void onStartup() {
-        // kick off immediately without blocking startup
-        runNowAsync();
-    }
 
     // Every day at 00:01 local server time
     @Schedule(hour = "0", minute = "1", second = "0",

--- a/src/main/java/com/frankies/bootcamp/model/BootcampAthlete.java
+++ b/src/main/java/com/frankies/bootcamp/model/BootcampAthlete.java
@@ -25,6 +25,14 @@ public class BootcampAthlete {
 
     private String sex;
 
+    private String city;
+
+    private String state;
+
+    private String country;
+
+    private String profileMedium;
+
     private Double goal;
 
     private String[] sickWeeks;
@@ -115,6 +123,38 @@ public class BootcampAthlete {
 
     public void setSex(String sex) {
         this.sex = sex;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public void setCity(String city) {
+        this.city = city;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public void setState(String state) {
+        this.state = state;
+    }
+
+    public String getCountry() {
+        return country;
+    }
+
+    public void setCountry(String country) {
+        this.country = country;
+    }
+
+    public String getProfileMedium() {
+        return profileMedium;
+    }
+
+    public void setProfileMedium(String profileMedium) {
+        this.profileMedium = profileMedium;
     }
 
     public Double getGoal() {

--- a/src/main/java/com/frankies/bootcamp/model/CompetitionInsights.java
+++ b/src/main/java/com/frankies/bootcamp/model/CompetitionInsights.java
@@ -46,6 +46,7 @@ public record CompetitionInsights(
     public record AthleteProfileSummary(
             String athleteId,
             String athleteName,
+            String profileMedium,
             int overallRank,
             String totalDistanceDisplay,
             double totalScore,

--- a/src/main/java/com/frankies/bootcamp/model/CompetitionInsights.java
+++ b/src/main/java/com/frankies/bootcamp/model/CompetitionInsights.java
@@ -50,6 +50,7 @@ public record CompetitionInsights(
             int overallRank,
             String totalDistanceDisplay,
             double totalScore,
+            double currentWeekPercentOfGoal,
             int activeWeeks,
             int sickWeeks,
             int goalCrushWeeks,

--- a/src/main/java/com/frankies/bootcamp/model/CompetitionInvitationPageView.java
+++ b/src/main/java/com/frankies/bootcamp/model/CompetitionInvitationPageView.java
@@ -1,0 +1,41 @@
+package com.frankies.bootcamp.model;
+
+import java.util.List;
+
+public class CompetitionInvitationPageView {
+    private final long competitionId;
+    private final String competitionName;
+    private final List<BootcampAthlete> acceptedAthletes;
+    private final List<CompetitionInvitationView> pendingInvitations;
+    private final List<CompetitionInviteCandidateView> candidates;
+    private final String searchQuery;
+    private final String feedbackMessage;
+    private final String errorMessage;
+
+    public CompetitionInvitationPageView(long competitionId,
+                                         String competitionName,
+    List<BootcampAthlete> acceptedAthletes,
+                                         List<CompetitionInvitationView> pendingInvitations,
+                                         List<CompetitionInviteCandidateView> candidates,
+                                         String searchQuery,
+                                         String feedbackMessage,
+                                         String errorMessage) {
+        this.competitionId = competitionId;
+        this.competitionName = competitionName;
+        this.acceptedAthletes = acceptedAthletes;
+        this.pendingInvitations = pendingInvitations;
+        this.candidates = candidates;
+        this.searchQuery = searchQuery;
+        this.feedbackMessage = feedbackMessage;
+        this.errorMessage = errorMessage;
+    }
+
+    public long getCompetitionId() { return competitionId; }
+    public String getCompetitionName() { return competitionName; }
+    public List<BootcampAthlete> getAcceptedAthletes() { return acceptedAthletes; }
+    public List<CompetitionInvitationView> getPendingInvitations() { return pendingInvitations; }
+    public List<CompetitionInviteCandidateView> getCandidates() { return candidates; }
+    public String getSearchQuery() { return searchQuery; }
+    public String getFeedbackMessage() { return feedbackMessage; }
+    public String getErrorMessage() { return errorMessage; }
+}

--- a/src/main/java/com/frankies/bootcamp/model/CompetitionInvitationStatus.java
+++ b/src/main/java/com/frankies/bootcamp/model/CompetitionInvitationStatus.java
@@ -1,0 +1,19 @@
+package com.frankies.bootcamp.model;
+
+public enum CompetitionInvitationStatus {
+    PENDING,
+    ACCEPTED,
+    DECLINED,
+    EXPIRED;
+
+    public String dbValue() {
+        return name().toLowerCase();
+    }
+
+    public static CompetitionInvitationStatus fromDbValue(String value) {
+        if (value == null) {
+            return null;
+        }
+        return CompetitionInvitationStatus.valueOf(value.trim().toUpperCase());
+    }
+}

--- a/src/main/java/com/frankies/bootcamp/model/CompetitionInvitationView.java
+++ b/src/main/java/com/frankies/bootcamp/model/CompetitionInvitationView.java
@@ -8,6 +8,9 @@ public class CompetitionInvitationView {
     private final String competitionName;
     private final String invitedEmail;
     private final String invitedUserId;
+    private final String invitedFirstname;
+    private final String invitedLastname;
+    private final String invitedDisplayName;
     private final String token;
     private final String status;
     private final String invitedByUserId;
@@ -30,11 +33,33 @@ public class CompetitionInvitationView {
                                      Instant expiresAt,
                                      Instant acceptedAt,
                                      Instant declinedAt) {
+        this(id, competitionId, competitionName, invitedEmail, invitedUserId, null, null, null, token, status, invitedByUserId, createdAt, updatedAt, expiresAt, acceptedAt, declinedAt);
+    }
+
+    public CompetitionInvitationView(long id,
+                                     long competitionId,
+                                     String competitionName,
+                                     String invitedEmail,
+                                     String invitedUserId,
+                                     String invitedFirstname,
+                                     String invitedLastname,
+                                     String invitedDisplayName,
+                                     String token,
+                                     String status,
+                                     String invitedByUserId,
+                                     Instant createdAt,
+                                     Instant updatedAt,
+                                     Instant expiresAt,
+                                     Instant acceptedAt,
+                                     Instant declinedAt) {
         this.id = id;
         this.competitionId = competitionId;
         this.competitionName = competitionName;
         this.invitedEmail = invitedEmail;
         this.invitedUserId = invitedUserId;
+        this.invitedFirstname = invitedFirstname;
+        this.invitedLastname = invitedLastname;
+        this.invitedDisplayName = invitedDisplayName;
         this.token = token;
         this.status = status;
         this.invitedByUserId = invitedByUserId;
@@ -50,6 +75,9 @@ public class CompetitionInvitationView {
     public String getCompetitionName() { return competitionName; }
     public String getInvitedEmail() { return invitedEmail; }
     public String getInvitedUserId() { return invitedUserId; }
+    public String getInvitedFirstname() { return invitedFirstname; }
+    public String getInvitedLastname() { return invitedLastname; }
+    public String getInvitedDisplayName() { return invitedDisplayName; }
     public String getToken() { return token; }
     public String getStatus() { return status; }
     public String getInvitedByUserId() { return invitedByUserId; }

--- a/src/main/java/com/frankies/bootcamp/model/CompetitionInvitationView.java
+++ b/src/main/java/com/frankies/bootcamp/model/CompetitionInvitationView.java
@@ -1,0 +1,65 @@
+package com.frankies.bootcamp.model;
+
+import java.time.Instant;
+
+public class CompetitionInvitationView {
+    private final long id;
+    private final long competitionId;
+    private final String competitionName;
+    private final String invitedEmail;
+    private final String invitedUserId;
+    private final String token;
+    private final String status;
+    private final String invitedByUserId;
+    private final Instant createdAt;
+    private final Instant updatedAt;
+    private final Instant expiresAt;
+    private final Instant acceptedAt;
+    private final Instant declinedAt;
+
+    public CompetitionInvitationView(long id,
+                                     long competitionId,
+                                     String competitionName,
+                                     String invitedEmail,
+                                     String invitedUserId,
+                                     String token,
+                                     String status,
+                                     String invitedByUserId,
+                                     Instant createdAt,
+                                     Instant updatedAt,
+                                     Instant expiresAt,
+                                     Instant acceptedAt,
+                                     Instant declinedAt) {
+        this.id = id;
+        this.competitionId = competitionId;
+        this.competitionName = competitionName;
+        this.invitedEmail = invitedEmail;
+        this.invitedUserId = invitedUserId;
+        this.token = token;
+        this.status = status;
+        this.invitedByUserId = invitedByUserId;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.expiresAt = expiresAt;
+        this.acceptedAt = acceptedAt;
+        this.declinedAt = declinedAt;
+    }
+
+    public long getId() { return id; }
+    public long getCompetitionId() { return competitionId; }
+    public String getCompetitionName() { return competitionName; }
+    public String getInvitedEmail() { return invitedEmail; }
+    public String getInvitedUserId() { return invitedUserId; }
+    public String getToken() { return token; }
+    public String getStatus() { return status; }
+    public String getInvitedByUserId() { return invitedByUserId; }
+    public Instant getCreatedAt() { return createdAt; }
+    public Instant getUpdatedAt() { return updatedAt; }
+    public Instant getExpiresAt() { return expiresAt; }
+    public Instant getAcceptedAt() { return acceptedAt; }
+    public Instant getDeclinedAt() { return declinedAt; }
+
+    public boolean isPending() {
+        return CompetitionInvitationStatus.PENDING.dbValue().equalsIgnoreCase(status);
+    }
+}

--- a/src/main/java/com/frankies/bootcamp/model/CompetitionInviteCandidateView.java
+++ b/src/main/java/com/frankies/bootcamp/model/CompetitionInviteCandidateView.java
@@ -1,0 +1,43 @@
+package com.frankies.bootcamp.model;
+
+public class CompetitionInviteCandidateView {
+    private final String userId;
+    private final String athleteId;
+    private final String displayName;
+    private final String email;
+    private final String profileMedium;
+    private final String city;
+    private final String state;
+    private final String country;
+    private final boolean alreadyInCompetition;
+
+    public CompetitionInviteCandidateView(String userId,
+                                          String athleteId,
+                                          String displayName,
+                                          String email,
+                                          String profileMedium,
+                                          String city,
+                                          String state,
+                                          String country,
+                                          boolean alreadyInCompetition) {
+        this.userId = userId;
+        this.athleteId = athleteId;
+        this.displayName = displayName;
+        this.email = email;
+        this.profileMedium = profileMedium;
+        this.city = city;
+        this.state = state;
+        this.country = country;
+        this.alreadyInCompetition = alreadyInCompetition;
+    }
+
+    public String getUserId() { return userId; }
+    public String getAthleteId() { return athleteId; }
+    public String getDisplayName() { return displayName; }
+    public String getEmail() { return email; }
+    public String getProfileMedium() { return profileMedium; }
+    public String getCity() { return city; }
+    public String getState() { return state; }
+    public String getCountry() { return country; }
+    public boolean isAlreadyInCompetition() { return alreadyInCompetition; }
+}

--- a/src/main/java/com/frankies/bootcamp/model/strava/StravaAuthResponse.java
+++ b/src/main/java/com/frankies/bootcamp/model/strava/StravaAuthResponse.java
@@ -278,6 +278,10 @@ public class StravaAuthResponse implements Serializable {
     bootcampAthlete.setExpiresAt(this.expires_at);
     bootcampAthlete.setId(this.athlete.id);
     bootcampAthlete.setSex(this.athlete.getSex());
+    bootcampAthlete.setCity(this.athlete.getCity());
+    bootcampAthlete.setState(this.athlete.getState());
+    bootcampAthlete.setCountry(this.athlete.getCountry());
+    bootcampAthlete.setProfileMedium(this.athlete.getProfile_medium());
     return bootcampAthlete;
   }
 }

--- a/src/main/java/com/frankies/bootcamp/model/strava/StravaRefreshResponse.java
+++ b/src/main/java/com/frankies/bootcamp/model/strava/StravaRefreshResponse.java
@@ -271,6 +271,10 @@ public class StravaRefreshResponse implements Serializable {
         bootcampAthlete.setEmail(currentAthlete.getEmail());
         bootcampAthlete.setGoal(currentAthlete.getGoal());
         bootcampAthlete.setSex(currentAthlete.getSex());
+        bootcampAthlete.setCity(currentAthlete.getCity());
+        bootcampAthlete.setState(currentAthlete.getState());
+        bootcampAthlete.setCountry(currentAthlete.getCountry());
+        bootcampAthlete.setProfileMedium(currentAthlete.getProfileMedium());
         return bootcampAthlete;
     }
 }

--- a/src/main/java/com/frankies/bootcamp/service/AiMessageService.java
+++ b/src/main/java/com/frankies/bootcamp/service/AiMessageService.java
@@ -178,6 +178,50 @@ public class AiMessageService {
         }
     }
 
+    public String rewriteCompetitionInviteMessage(String competitionName, String currentMessage) {
+        String trimmedMessage = currentMessage == null ? "" : currentMessage.trim();
+        String trimmedCompetitionName = competitionName == null ? "" : competitionName.trim();
+        if (service == null) {
+            if (trimmedMessage.isBlank()) {
+                return "Frankies Bootcamp is all sports, all effort, all welcome. Come join the fun.";
+            }
+            return trimmedMessage;
+        }
+
+        String prompt;
+        if (trimmedMessage.isBlank()) {
+            prompt = "Write a fresh invitation message for a Frankies Bootcamp competition. " +
+                    "Use the motto: all sports are welcome, all sports are valid effort. " +
+                    "Keep it warm, inviting, and concise. " +
+                    (trimmedCompetitionName.isBlank() ? "" : "The competition is named " + trimmedCompetitionName + ". ") +
+                    "Do not mention AI. Keep it under 45 words.";
+        } else {
+            prompt = "Refine this invitation message without changing its intent or personality too much. " +
+                    "Keep the user's voice, tighten grammar and flow, and keep it warm and inviting. " +
+                    "If the message is already specific, preserve the specifics. " +
+                    "If it is vague, sharpen it gently rather than rewriting from scratch. " +
+                    (trimmedCompetitionName.isBlank() ? "" : "The competition is named " + trimmedCompetitionName + ". ") +
+                    "Message: " + trimmedMessage + ". Keep it under 55 words.";
+        }
+
+        ChatMessage systemMsg = new ChatMessage("system", "You write concise, friendly invitation copy for a sports challenge app.");
+        ChatMessage userMsg = new ChatMessage("user", prompt);
+        ChatCompletionRequest req = ChatCompletionRequest.builder()
+                .model("gpt-4")
+                .messages(List.of(systemMsg, userMsg))
+                .maxTokens(80)
+                .temperature(0.7)
+                .build();
+        try {
+            return service.createChatCompletion(req).getChoices().get(0).getMessage().getContent();
+        } catch (Exception e) {
+            log.warn("Could not rewrite competition invite message", e);
+            return trimmedMessage.isBlank()
+                    ? "Frankies Bootcamp is all sports, all effort, all welcome. Come join the fun."
+                    : trimmedMessage;
+        }
+    }
+
     public String getZenBotReply(String question, String athleteName, int conversationTurn, String statsContext) {
         if (service == null) {
             return "Even without cosmic Wi-Fi, a small walk can answer many questions.";

--- a/src/main/java/com/frankies/bootcamp/service/AuthService.java
+++ b/src/main/java/com/frankies/bootcamp/service/AuthService.java
@@ -5,20 +5,30 @@ import com.frankies.bootcamp.model.BootcampAthlete;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
+import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
 import java.sql.SQLException;
 import java.util.Locale;
 
+import org.wildfly.security.credential.store.CredentialStoreException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 @ApplicationScoped
 public class AuthService {
+    private static final Logger log = LoggerFactory.getLogger(AuthService.class);
+
     // Identity model notes:
     // - app_users is the canonical application identity used by session auth and future RBAC.
     // - auth_identities allows multiple login providers to point at the same logical user later.
     // - athletes remains the current domain/person record for compatibility with the existing app.
     private DBService db;
+    private StravaService stravaService;
 
     @Inject
-    public AuthService(DBService db) {
+    public AuthService(DBService db, StravaService stravaService) {
         this.db = db;
+        this.stravaService = stravaService;
     }
 
     protected AuthService() {
@@ -82,6 +92,14 @@ public class AuthService {
         }
         if (athlete != null && (athlete.getEmail() == null || athlete.getEmail().isBlank())) {
             athlete.setEmail(user.getEmail());
+        }
+        if (athlete != null && stravaService != null) {
+            try {
+                athlete = stravaService.backfillAthleteProfileIfMissing(athlete);
+            } catch (CredentialStoreException | NoSuchAlgorithmException | IOException e) {
+                // Keep login flowing; the profile backfill is opportunistic.
+                log.warn("Failed to backfill Strava athlete profile for {}", user.getEmail(), e);
+            }
         }
         return athlete;
     }

--- a/src/main/java/com/frankies/bootcamp/service/AuthSessionService.java
+++ b/src/main/java/com/frankies/bootcamp/service/AuthSessionService.java
@@ -11,6 +11,7 @@ public class AuthSessionService {
     public static final String AUTH_USER_SESSION_KEY = "authUser";
     public static final String SELECTED_COMPETITION_ID_SESSION_KEY = "selectedCompetitionId";
     public static final String PENDING_INVITATION_TOKEN_SESSION_KEY = "pendingCompetitionInvitationToken";
+    public static final String HISTORY_MOTIVATIONAL_MESSAGE_HIDDEN_SESSION_KEY = "historyMotivationalMessageHidden";
     private static final int DEFAULT_SESSION_TIMEOUT_SECONDS = 60 * 60 * 24 * 30;
 
     public AuthenticatedUser getAuthenticatedUser(HttpServletRequest request) {
@@ -89,5 +90,19 @@ public class AuthSessionService {
 
     public void clearPendingInvitationToken(HttpServletRequest request) {
         setPendingInvitationToken(request, null);
+    }
+
+    public boolean isHistoryMotivationalMessageHidden(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        if (session == null) {
+            return false;
+        }
+        Object hidden = session.getAttribute(HISTORY_MOTIVATIONAL_MESSAGE_HIDDEN_SESSION_KEY);
+        return hidden instanceof Boolean value && value;
+    }
+
+    public void hideHistoryMotivationalMessage(HttpServletRequest request) {
+        HttpSession session = request.getSession(true);
+        session.setAttribute(HISTORY_MOTIVATIONAL_MESSAGE_HIDDEN_SESSION_KEY, Boolean.TRUE);
     }
 }

--- a/src/main/java/com/frankies/bootcamp/service/AuthSessionService.java
+++ b/src/main/java/com/frankies/bootcamp/service/AuthSessionService.java
@@ -10,6 +10,7 @@ import jakarta.servlet.http.HttpSession;
 public class AuthSessionService {
     public static final String AUTH_USER_SESSION_KEY = "authUser";
     public static final String SELECTED_COMPETITION_ID_SESSION_KEY = "selectedCompetitionId";
+    public static final String PENDING_INVITATION_TOKEN_SESSION_KEY = "pendingCompetitionInvitationToken";
     private static final int DEFAULT_SESSION_TIMEOUT_SECONDS = 60 * 60 * 24 * 30;
 
     public AuthenticatedUser getAuthenticatedUser(HttpServletRequest request) {
@@ -66,5 +67,27 @@ public class AuthSessionService {
 
     public boolean hasSelectedCompetition(HttpServletRequest request) {
         return getSelectedCompetitionId(request) != null;
+    }
+
+    public String getPendingInvitationToken(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        if (session == null) {
+            return null;
+        }
+        Object token = session.getAttribute(PENDING_INVITATION_TOKEN_SESSION_KEY);
+        return token instanceof String value ? value : null;
+    }
+
+    public void setPendingInvitationToken(HttpServletRequest request, String token) {
+        HttpSession session = request.getSession(true);
+        if (token == null || token.isBlank()) {
+            session.removeAttribute(PENDING_INVITATION_TOKEN_SESSION_KEY);
+            return;
+        }
+        session.setAttribute(PENDING_INVITATION_TOKEN_SESSION_KEY, token);
+    }
+
+    public void clearPendingInvitationToken(HttpServletRequest request) {
+        setPendingInvitationToken(request, null);
     }
 }

--- a/src/main/java/com/frankies/bootcamp/service/CompetitionAccessService.java
+++ b/src/main/java/com/frankies/bootcamp/service/CompetitionAccessService.java
@@ -1,0 +1,24 @@
+package com.frankies.bootcamp.service;
+
+import com.frankies.bootcamp.model.AuthenticatedUser;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.Locale;
+import java.util.Set;
+
+@ApplicationScoped
+public class CompetitionAccessService {
+    private static final Set<String> COMPETITION_SETUP_ALLOWLIST = Set.of(
+            "millslf@gmail.com",
+            "frankiesbootcamp.gmail.com",
+            "conlik@gmail.com",
+            "millslf@yahoo.com"
+    );
+
+    public boolean canAccessCompetitionSetup(AuthenticatedUser user) {
+        if (user == null || user.getEmail() == null || user.getEmail().isBlank()) {
+            return false;
+        }
+        return COMPETITION_SETUP_ALLOWLIST.contains(user.getEmail().trim().toLowerCase(Locale.ROOT));
+    }
+}

--- a/src/main/java/com/frankies/bootcamp/service/CompetitionAccessService.java
+++ b/src/main/java/com/frankies/bootcamp/service/CompetitionAccessService.java
@@ -10,7 +10,7 @@ import java.util.Set;
 public class CompetitionAccessService {
     private static final Set<String> COMPETITION_SETUP_ALLOWLIST = Set.of(
             "millslf@gmail.com",
-            "frankiesbootcamp.gmail.com",
+            "frankiesbootcamp@gmail.com",
             "conlik@gmail.com",
             "millslf@yahoo.com"
     );

--- a/src/main/java/com/frankies/bootcamp/service/CompetitionAccessService.java
+++ b/src/main/java/com/frankies/bootcamp/service/CompetitionAccessService.java
@@ -10,7 +10,7 @@ import java.util.Set;
 public class CompetitionAccessService {
     private static final Set<String> COMPETITION_SETUP_ALLOWLIST = Set.of(
             "millslf@gmail.com",
-            "frankiesbootcamp@gmail.com",
+            "support@mail.frankiesbootamp.com",
             "conlik@gmail.com",
             "millslf@yahoo.com"
     );

--- a/src/main/java/com/frankies/bootcamp/service/CompetitionInsightsService.java
+++ b/src/main/java/com/frankies/bootcamp/service/CompetitionInsightsService.java
@@ -4,6 +4,7 @@ import com.frankies.bootcamp.model.BootcampAthlete;
 import com.frankies.bootcamp.model.CompetitionInsights;
 import com.frankies.bootcamp.model.PerformanceResponse;
 import com.frankies.bootcamp.model.WeeklyPerformance;
+import jakarta.inject.Inject;
 import jakarta.enterprise.context.ApplicationScoped;
 
 import java.util.ArrayList;
@@ -16,6 +17,8 @@ import java.util.Objects;
 
 @ApplicationScoped
 public class CompetitionInsightsService {
+    @Inject
+    private DBService dbService;
 
     public CompetitionInsights buildInsights(List<PerformanceResponse> performances, String selectedAthleteId) {
         return buildInsights(performances, selectedAthleteId, false);
@@ -140,6 +143,7 @@ public class CompetitionInsightsService {
         return new CompetitionInsights.AthleteProfileSummary(
                 athleteId(performance),
                 athleteName(performance),
+                profileMedium(performance),
                 overallRank,
                 "",
                 weeks.values().stream().mapToDouble(WeeklyPerformance::getWeekScore).sum(),
@@ -286,6 +290,33 @@ public class CompetitionInsightsService {
         String name = ((athlete.getFirstname() == null ? "" : athlete.getFirstname()) + " "
                 + (athlete.getLastname() == null ? "" : athlete.getLastname())).trim();
         return name.isBlank() ? "Athlete" : name;
+    }
+
+    private String profileMedium(PerformanceResponse performance) {
+        BootcampAthlete athlete = performance.getAthlete();
+        String storedProfileMedium = storedProfileMedium(athlete);
+        if (storedProfileMedium != null) {
+            return storedProfileMedium;
+        }
+        if (athlete != null && athlete.getProfileMedium() != null && !athlete.getProfileMedium().isBlank()) {
+            return athlete.getProfileMedium();
+        }
+        return null;
+    }
+
+    private String storedProfileMedium(BootcampAthlete athlete) {
+        if (athlete == null || athlete.getId() == null || athlete.getId().isBlank() || dbService == null) {
+            return null;
+        }
+        try {
+            BootcampAthlete storedAthlete = dbService.findAthleteByStravaID(athlete.getId());
+            if (storedAthlete != null && storedAthlete.getProfileMedium() != null && !storedAthlete.getProfileMedium().isBlank()) {
+                return storedAthlete.getProfileMedium();
+            }
+        } catch (Exception ignored) {
+            // fall through to no avatar
+        }
+        return null;
     }
 
     private double value(Double value) {

--- a/src/main/java/com/frankies/bootcamp/service/CompetitionInsightsService.java
+++ b/src/main/java/com/frankies/bootcamp/service/CompetitionInsightsService.java
@@ -122,8 +122,11 @@ public class CompetitionInsightsService {
     private CompetitionInsights.AthleteProfileSummary profile(PerformanceResponse performance,
                                                               int latestInsightWeek,
                                                               int overallRank) {
+        Map<Integer, WeeklyPerformance> allWeeks = weeklyPerformances(performance);
         Map<Integer, WeeklyPerformance> weeks = weeklyPerformancesThrough(performance, latestInsightWeek);
         Map<String, Double> sports = sportTotals(weeks);
+        int currentWeek = latestWeek(allWeeks);
+        WeeklyPerformance currentWeekPerformance = currentWeek == 0 ? null : allWeeks.get(currentWeek);
 
         int activeWeeks = (int) weeks.values().stream()
                 .filter(week -> week.getTotalDistance() > 0.0 || week.getWeekScore() > 0.0 || week.isSick())
@@ -139,6 +142,7 @@ public class CompetitionInsightsService {
                 .max(Map.Entry.comparingByValue())
                 .map(Map.Entry::getKey)
                 .orElse("None yet");
+        double totalScoreToDate = allWeeks.values().stream().mapToDouble(WeeklyPerformance::getWeekScore).sum();
 
         return new CompetitionInsights.AthleteProfileSummary(
                 athleteId(performance),
@@ -146,7 +150,8 @@ public class CompetitionInsightsService {
                 profileMedium(performance),
                 overallRank,
                 "",
-                weeks.values().stream().mapToDouble(WeeklyPerformance::getWeekScore).sum(),
+                totalScoreToDate,
+                currentWeekPerformance == null ? 0.0 : currentWeekPerformance.getTotalPercentOfGoal(),
                 activeWeeks,
                 sickWeeks,
                 goalCrushWeeks,
@@ -244,6 +249,13 @@ public class CompetitionInsightsService {
     private int latestWeek(List<PerformanceResponse> performances) {
         return performances.stream()
                 .flatMap(performance -> weeklyPerformances(performance).keySet().stream())
+                .mapToInt(Integer::intValue)
+                .max()
+                .orElse(0);
+    }
+
+    private int latestWeek(Map<Integer, WeeklyPerformance> weeks) {
+        return weeks.keySet().stream()
                 .mapToInt(Integer::intValue)
                 .max()
                 .orElse(0);

--- a/src/main/java/com/frankies/bootcamp/service/CompetitionInvitationEmailService.java
+++ b/src/main/java/com/frankies/bootcamp/service/CompetitionInvitationEmailService.java
@@ -1,0 +1,81 @@
+package com.frankies.bootcamp.service;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import okhttp3.FormBody;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.jboss.logging.Logger;
+
+import java.io.IOException;
+
+@ApplicationScoped
+public class CompetitionInvitationEmailService {
+    private static final Logger LOG = Logger.getLogger(CompetitionInvitationEmailService.class);
+    private final OkHttpClient httpClient = new OkHttpClient();
+
+    @Inject
+    public CompetitionInvitationEmailService() {
+    }
+
+    protected CompetitionInvitationEmailService(boolean ignored) {
+    }
+
+    public boolean sendInvitation(String to, String subject, String body) {
+        String apiKey = firstNonBlank(System.getProperty("MAILGUN_API_KEY"), System.getenv("MAILGUN_API_KEY"));
+        String domain = firstNonBlank(System.getProperty("MAILGUN_DOMAIN"), System.getenv("MAILGUN_DOMAIN"));
+        String from = firstNonBlank(System.getProperty("MAILGUN_FROM"), System.getenv("MAILGUN_FROM"));
+        String smtpHost = firstNonBlank(System.getProperty("MAILGUN_SMTP_HOST"), System.getenv("MAILGUN_SMTP_HOST"));
+        String apiBaseUrl = firstNonBlank(System.getProperty("MAILGUN_API_BASE_URL"), System.getenv("MAILGUN_API_BASE_URL"), inferApiBaseUrl(smtpHost));
+
+        if (from == null && domain != null) {
+            from = "invitations@" + domain;
+        }
+        if (apiKey == null || domain == null || from == null) {
+            return false;
+        }
+
+        LOG.infof("Sending competition invite email from=%s to=%s domain=%s", from, to, domain);
+        Request request = new Request.Builder()
+                .url(apiBaseUrl.replaceAll("/+$", "") + "/v3/" + domain + "/messages")
+                .addHeader("Authorization", okhttp3.Credentials.basic("api", apiKey))
+                .post(new FormBody.Builder()
+                        .add("from", from)
+                        .add("to", to)
+                        .add("subject", subject)
+                        .add("text", body)
+                        .build())
+                .build();
+
+        try (Response response = httpClient.newCall(request).execute()) {
+            if (response.isSuccessful()) {
+                String responseBody = response.body() == null ? "" : response.body().string();
+                LOG.infof("Competition invite email sent from=%s to=%s domain=%s mailgunResponse=%s", from, to, domain, responseBody);
+                return true;
+            }
+            String responseBody = response.body() == null ? "" : response.body().string();
+            LOG.errorf("Competition invite email failed from=%s to=%s domain=%s status=%d response=%s", from, to, domain, response.code(), responseBody);
+            throw new RuntimeException("Unable to send invitation email via Mailgun: " + response.code() + " " + responseBody);
+        } catch (IOException e) {
+            LOG.errorf(e, "Competition invite email IO failure from=%s to=%s domain=%s", from, to, domain);
+            throw new RuntimeException("Unable to send invitation email via Mailgun", e);
+        }
+    }
+
+    private String firstNonBlank(String... values) {
+        for (String value : values) {
+            if (value != null && !value.isBlank()) {
+                return value.trim();
+            }
+        }
+        return null;
+    }
+
+    private String inferApiBaseUrl(String smtpHost) {
+        if (smtpHost != null && smtpHost.contains(".eu.")) {
+            return "https://api.eu.mailgun.net";
+        }
+        return "https://api.mailgun.net";
+    }
+}

--- a/src/main/java/com/frankies/bootcamp/service/CompetitionInvitationService.java
+++ b/src/main/java/com/frankies/bootcamp/service/CompetitionInvitationService.java
@@ -7,6 +7,7 @@ import com.frankies.bootcamp.model.CompetitionInvitationPageView;
 import com.frankies.bootcamp.model.CompetitionInvitationStatus;
 import com.frankies.bootcamp.model.CompetitionInvitationView;
 import com.frankies.bootcamp.model.CompetitionSummaryView;
+import com.frankies.bootcamp.util.EmailDisplayUtil;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.servlet.http.HttpServletRequest;
@@ -192,28 +193,28 @@ public class CompetitionInvitationService {
         return invitation;
     }
 
-    public InviteSubmissionResult inviteByEmails(long competitionId, String invitedByUserId, String rawEmails, HttpServletRequest request) throws SQLException {
+    public InviteSubmissionResult inviteByEmails(long competitionId, String invitedByUserId, String rawEmails, String customMessage, HttpServletRequest request) throws SQLException {
         Map<String, String> normalizedToOriginal = splitEmails(rawEmails);
         List<InviteRecord> created = new ArrayList<>();
         List<String> errors = new ArrayList<>();
         for (Map.Entry<String, String> entry : normalizedToOriginal.entrySet()) {
             String normalizedEmail = entry.getKey();
             if (!isValidEmail(normalizedEmail)) {
-                errors.add(entry.getValue() + ": invalid email");
+                errors.add(EmailDisplayUtil.maskEmail(entry.getValue()) + ": invalid email");
                 continue;
             }
             if (repository.hasActiveInvitationForEmail(competitionId, normalizedEmail)) {
-                errors.add(entry.getValue() + ": already invited");
+                errors.add(EmailDisplayUtil.maskEmail(entry.getValue()) + ": already invited");
                 continue;
             }
             long invitationId = createSingleInvitation(competitionId, normalizedEmail, null, invitedByUserId);
             created.add(new InviteRecord(invitationId, normalizedEmail, null));
-            sendInvitationEmail(competitionId, invitationId, normalizedEmail, request);
+            sendInvitationEmail(competitionId, invitationId, normalizedEmail, customMessage, request);
         }
         return new InviteSubmissionResult(created, errors);
     }
 
-    public InviteRecord inviteExistingUser(long competitionId, String invitedByUserId, String invitedUserId, String invitedEmail, HttpServletRequest request) throws SQLException {
+    public InviteRecord inviteExistingUser(long competitionId, String invitedByUserId, String invitedUserId, String invitedEmail, String customMessage, HttpServletRequest request) throws SQLException {
         String normalizedEmail = normalizeEmail(invitedEmail);
         if (normalizedEmail == null) {
             throw new IllegalArgumentException("Selected athlete must have an email address.");
@@ -225,7 +226,7 @@ public class CompetitionInvitationService {
             throw new IllegalArgumentException("Selected athlete already has a pending invite.");
         }
         long invitationId = createSingleInvitation(competitionId, normalizedEmail, invitedUserId, invitedByUserId);
-        sendInvitationEmail(competitionId, invitationId, normalizedEmail, request);
+        sendInvitationEmail(competitionId, invitationId, normalizedEmail, customMessage, request);
         return new InviteRecord(invitationId, normalizedEmail, invitedUserId);
     }
 
@@ -269,19 +270,19 @@ public class CompetitionInvitationService {
         CompetitionInvitationView invitation = repository.findInvitationById(invitationId);
         if (invitation != null && invitation.getInvitedEmail() != null) {
             String inviteUrl = buildInvitationUrl(baseUrl, invitation.getToken());
-            emailService.sendInvitation(invitation.getInvitedEmail(), "You're invited to " + competitionName, buildBody(competitionName, inviteUrl));
+            emailService.sendInvitation(invitation.getInvitedEmail(), "You're invited to " + competitionName, buildBody(competitionName, inviteUrl, null));
         }
         return invitationId;
     }
 
-    private void sendInvitationEmail(long competitionId, long invitationId, String invitedEmail, HttpServletRequest request) throws SQLException {
+    private void sendInvitationEmail(long competitionId, long invitationId, String invitedEmail, String customMessage, HttpServletRequest request) throws SQLException {
         CompetitionInvitationView invitation = repository.findInvitationById(invitationId);
         CompetitionSummaryView competition = repository.findCompetition(competitionId);
         if (invitation == null || competition == null || invitedEmail == null) {
             return;
         }
         String inviteUrl = buildInvitationUrl(baseUrl(request), invitation.getToken());
-        emailService.sendInvitation(invitedEmail, "You're invited to " + competition.getName(), buildBody(competition.getName(), inviteUrl));
+        emailService.sendInvitation(invitedEmail, "You're invited to " + competition.getName(), buildBody(competition.getName(), inviteUrl, customMessage));
     }
 
     public String buildInvitationUrl(String baseUrl, String token) {
@@ -339,8 +340,14 @@ public class CompetitionInvitationService {
         return UUID.randomUUID().toString().replace("-", "") + UUID.randomUUID().toString().replace("-", "");
     }
 
-    private String buildBody(String competitionName, String inviteUrl) {
-        return "You have been invited to join " + competitionName + ".\n\nOpen this link to continue: " + inviteUrl;
+    private String buildBody(String competitionName, String inviteUrl, String customMessage) {
+        StringBuilder body = new StringBuilder();
+        body.append("You have been invited to join ").append(competitionName).append('.');
+        if (customMessage != null && !customMessage.isBlank()) {
+            body.append("\n\n").append(customMessage.trim());
+        }
+        body.append("\n\nOpen this link to continue: ").append(inviteUrl);
+        return body.toString();
     }
 
     public record InviteRecord(long invitationId, String invitedEmail, String invitedUserId) {}

--- a/src/main/java/com/frankies/bootcamp/service/CompetitionInvitationService.java
+++ b/src/main/java/com/frankies/bootcamp/service/CompetitionInvitationService.java
@@ -1,0 +1,354 @@
+package com.frankies.bootcamp.service;
+
+import com.frankies.bootcamp.model.AuthenticatedUser;
+import com.frankies.bootcamp.model.BootcampAthlete;
+import com.frankies.bootcamp.model.CompetitionInviteCandidateView;
+import com.frankies.bootcamp.model.CompetitionInvitationPageView;
+import com.frankies.bootcamp.model.CompetitionInvitationStatus;
+import com.frankies.bootcamp.model.CompetitionInvitationView;
+import com.frankies.bootcamp.model.CompetitionSummaryView;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.sql.SQLException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+@ApplicationScoped
+public class CompetitionInvitationService {
+    private static final Pattern EMAIL_SPLIT = Pattern.compile("[,;\\n\\r\\t ]+");
+
+    interface InvitationRepository {
+        boolean isCompetitionAdmin(long competitionId, String athleteId) throws SQLException;
+        boolean athleteBelongsToCompetition(String athleteId, long competitionId) throws SQLException;
+        boolean hasActiveInvitationForEmail(long competitionId, String normalizedEmail) throws SQLException;
+        boolean hasActiveInvitationForUser(long competitionId, String invitedUserId) throws SQLException;
+        long createInvitation(long competitionId, String invitedEmail, String invitedUserId, String token, String invitedByUserId, Instant expiresAt) throws SQLException;
+        CompetitionInvitationView findInvitationByToken(String token) throws SQLException;
+        CompetitionInvitationView findInvitationById(long invitationId) throws SQLException;
+        List<CompetitionInvitationView> listPendingInvitationsForUser(String userId, String email, String athleteId) throws SQLException;
+        List<CompetitionInvitationView> listPendingInvitationsForCompetition(long competitionId) throws SQLException;
+        List<BootcampAthlete> listCompetitionAthletes(long competitionId) throws SQLException;
+        List<CompetitionInviteCandidateView> searchInviteCandidates(long competitionId, String query) throws SQLException;
+        void acceptInvitation(long invitationId, String athleteId, double startingGoal) throws SQLException;
+        void declineInvitation(long invitationId) throws SQLException;
+        void expireInvitation(long invitationId) throws SQLException;
+        CompetitionInvitationView getInvitationForCompetitionAndToken(long competitionId, String token) throws SQLException;
+        CompetitionSummaryView findCompetition(long competitionId) throws SQLException;
+    }
+
+    private final InvitationRepository repository;
+    private final CompetitionInvitationEmailService emailService;
+
+    @Inject
+    public CompetitionInvitationService(DBService dbService, CompetitionInvitationEmailService emailService) {
+        this.repository = new InvitationRepository() {
+            @Override
+            public boolean isCompetitionAdmin(long competitionId, String athleteId) throws SQLException {
+                return dbService.isCompetitionAdmin(competitionId, athleteId);
+            }
+
+            @Override
+            public boolean athleteBelongsToCompetition(String athleteId, long competitionId) throws SQLException {
+                return dbService.athleteBelongsToCompetition(athleteId, competitionId);
+            }
+
+            @Override
+            public boolean hasActiveInvitationForEmail(long competitionId, String normalizedEmail) throws SQLException {
+                return dbService.hasActiveCompetitionInvitationForEmail(competitionId, normalizedEmail);
+            }
+
+            @Override
+            public boolean hasActiveInvitationForUser(long competitionId, String invitedUserId) throws SQLException {
+                return dbService.hasActiveCompetitionInvitationForUser(competitionId, invitedUserId);
+            }
+
+            @Override
+            public long createInvitation(long competitionId, String invitedEmail, String invitedUserId, String token, String invitedByUserId, Instant expiresAt) throws SQLException {
+                return dbService.createCompetitionInvitation(competitionId, invitedEmail, invitedUserId, token, invitedByUserId, expiresAt);
+            }
+
+            @Override
+            public CompetitionInvitationView findInvitationByToken(String token) throws SQLException {
+                return dbService.findCompetitionInvitationByToken(token);
+            }
+
+            @Override
+            public CompetitionInvitationView findInvitationById(long invitationId) throws SQLException {
+                return dbService.findCompetitionInvitationById(invitationId);
+            }
+
+            @Override
+            public List<CompetitionInvitationView> listPendingInvitationsForUser(String userId, String email, String athleteId) throws SQLException {
+                return dbService.listPendingCompetitionInvitationsForUser(userId, email, athleteId);
+            }
+
+            @Override
+            public List<CompetitionInvitationView> listPendingInvitationsForCompetition(long competitionId) throws SQLException {
+                return dbService.listPendingCompetitionInvitationsForCompetition(competitionId);
+            }
+
+            @Override
+            public List<BootcampAthlete> listCompetitionAthletes(long competitionId) throws SQLException {
+                return dbService.listCompetitionAthletes(competitionId);
+            }
+
+            @Override
+            public List<CompetitionInviteCandidateView> searchInviteCandidates(long competitionId, String query) throws SQLException {
+                return dbService.searchCompetitionInviteCandidates(competitionId, query);
+            }
+
+            @Override
+            public void acceptInvitation(long invitationId, String athleteId, double startingGoal) throws SQLException {
+                dbService.acceptCompetitionInvitation(invitationId, athleteId, startingGoal);
+            }
+
+            @Override
+            public void declineInvitation(long invitationId) throws SQLException {
+                dbService.declineCompetitionInvitation(invitationId);
+            }
+
+            @Override
+            public void expireInvitation(long invitationId) throws SQLException {
+                dbService.expireCompetitionInvitation(invitationId);
+            }
+
+            @Override
+            public CompetitionInvitationView getInvitationForCompetitionAndToken(long competitionId, String token) throws SQLException {
+                return dbService.findCompetitionInvitationByCompetitionAndToken(competitionId, token);
+            }
+
+            @Override
+            public com.frankies.bootcamp.model.CompetitionSummaryView findCompetition(long competitionId) throws SQLException {
+                return dbService.findCompetitionSummary(competitionId);
+            }
+        };
+        this.emailService = emailService;
+    }
+
+    protected CompetitionInvitationService() {
+        this.repository = null;
+        this.emailService = null;
+    }
+
+    CompetitionInvitationService(InvitationRepository repository, CompetitionInvitationEmailService emailService) {
+        this.repository = repository;
+        this.emailService = emailService;
+    }
+
+    public boolean isAdmin(long competitionId, String athleteId) throws SQLException {
+        return repository.isCompetitionAdmin(competitionId, athleteId);
+    }
+
+    public CompetitionInvitationPageView loadAdminPage(long competitionId, String query) throws SQLException {
+        CompetitionSummaryView competition = repository.findCompetition(competitionId);
+        List<BootcampAthlete> accepted = repository.listCompetitionAthletes(competitionId);
+        List<CompetitionInvitationView> pending = repository.listPendingInvitationsForCompetition(competitionId);
+        List<CompetitionInviteCandidateView> candidates = query == null || query.isBlank()
+                ? List.of()
+                : repository.searchInviteCandidates(competitionId, query.trim());
+        return new CompetitionInvitationPageView(
+                competitionId,
+                competition == null ? "Competition" : competition.getName(),
+                accepted,
+                pending,
+                candidates,
+                query,
+                null,
+                null
+        );
+    }
+
+    public List<CompetitionInvitationView> listPendingForUser(AuthenticatedUser user, BootcampAthlete athlete) throws SQLException {
+        String userId = user == null ? null : user.getUserId();
+        String email = user == null ? null : user.getEmail();
+        String athleteId = athlete == null ? null : athlete.getId();
+        return repository.listPendingInvitationsForUser(userId, email, athleteId);
+    }
+
+    public CompetitionInvitationView resolveInvitationToken(String token) throws SQLException {
+        if (token == null || token.isBlank()) {
+            return null;
+        }
+        CompetitionInvitationView invitation = repository.findInvitationByToken(token.trim());
+        if (invitation == null) {
+            return null;
+        }
+        if (!CompetitionInvitationStatus.PENDING.dbValue().equalsIgnoreCase(invitation.getStatus())) {
+            return invitation;
+        }
+        if (invitation.getExpiresAt() != null && invitation.getExpiresAt().isBefore(Instant.now())) {
+            repository.expireInvitation(invitation.getId());
+            return repository.findInvitationById(invitation.getId());
+        }
+        return invitation;
+    }
+
+    public InviteSubmissionResult inviteByEmails(long competitionId, String invitedByUserId, String rawEmails, HttpServletRequest request) throws SQLException {
+        Map<String, String> normalizedToOriginal = splitEmails(rawEmails);
+        List<InviteRecord> created = new ArrayList<>();
+        List<String> errors = new ArrayList<>();
+        for (Map.Entry<String, String> entry : normalizedToOriginal.entrySet()) {
+            String normalizedEmail = entry.getKey();
+            if (!isValidEmail(normalizedEmail)) {
+                errors.add(entry.getValue() + ": invalid email");
+                continue;
+            }
+            if (repository.hasActiveInvitationForEmail(competitionId, normalizedEmail)) {
+                errors.add(entry.getValue() + ": already invited");
+                continue;
+            }
+            long invitationId = createSingleInvitation(competitionId, normalizedEmail, null, invitedByUserId);
+            created.add(new InviteRecord(invitationId, normalizedEmail, null));
+            sendInvitationEmail(competitionId, invitationId, normalizedEmail, request);
+        }
+        return new InviteSubmissionResult(created, errors);
+    }
+
+    public InviteRecord inviteExistingUser(long competitionId, String invitedByUserId, String invitedUserId, String invitedEmail, HttpServletRequest request) throws SQLException {
+        String normalizedEmail = normalizeEmail(invitedEmail);
+        if (normalizedEmail == null) {
+            throw new IllegalArgumentException("Selected athlete must have an email address.");
+        }
+        if (invitedUserId != null && repository.athleteBelongsToCompetition(invitedUserId, competitionId)) {
+            throw new IllegalArgumentException("Selected athlete is already active in this competition.");
+        }
+        if (repository.hasActiveInvitationForEmail(competitionId, normalizedEmail) || (invitedUserId != null && repository.hasActiveInvitationForUser(competitionId, invitedUserId))) {
+            throw new IllegalArgumentException("Selected athlete already has a pending invite.");
+        }
+        long invitationId = createSingleInvitation(competitionId, normalizedEmail, invitedUserId, invitedByUserId);
+        sendInvitationEmail(competitionId, invitationId, normalizedEmail, request);
+        return new InviteRecord(invitationId, normalizedEmail, invitedUserId);
+    }
+
+    public InvitationDecisionResult acceptInvitation(long invitationId, BootcampAthlete athlete, double startingGoal, String userId) throws SQLException {
+        CompetitionInvitationView invitation = repository.findInvitationById(invitationId);
+        if (invitation == null) {
+            return InvitationDecisionResult.error("Invitation not found.");
+        }
+        if (!CompetitionInvitationStatus.PENDING.dbValue().equalsIgnoreCase(invitation.getStatus())) {
+            return InvitationDecisionResult.error("Invitation is already " + invitation.getStatus() + ".");
+        }
+        if (invitation.getExpiresAt() != null && invitation.getExpiresAt().isBefore(Instant.now())) {
+            repository.expireInvitation(invitationId);
+            return InvitationDecisionResult.error("Invitation has expired.");
+        }
+        if (athlete == null || athlete.getId() == null || athlete.getId().isBlank()) {
+            return InvitationDecisionResult.error("Strava link required.");
+        }
+        repository.acceptInvitation(invitationId, athlete.getId(), startingGoal);
+        return InvitationDecisionResult.success("Invitation accepted.");
+    }
+
+    public InvitationDecisionResult declineInvitation(long invitationId) throws SQLException {
+        CompetitionInvitationView invitation = repository.findInvitationById(invitationId);
+        if (invitation == null) {
+            return InvitationDecisionResult.error("Invitation not found.");
+        }
+        if (CompetitionInvitationStatus.PENDING.dbValue().equalsIgnoreCase(invitation.getStatus())) {
+            repository.declineInvitation(invitationId);
+        }
+        return InvitationDecisionResult.success("Invitation declined.");
+    }
+
+    public long createInvitationAndNotify(long competitionId,
+                                          String invitedByUserId,
+                                          String invitedEmail,
+                                          String invitedUserId,
+                                          String baseUrl,
+                                          String competitionName) throws SQLException {
+        long invitationId = createSingleInvitation(competitionId, normalizeEmail(invitedEmail), invitedUserId, invitedByUserId);
+        CompetitionInvitationView invitation = repository.findInvitationById(invitationId);
+        if (invitation != null && invitation.getInvitedEmail() != null) {
+            String inviteUrl = buildInvitationUrl(baseUrl, invitation.getToken());
+            emailService.sendInvitation(invitation.getInvitedEmail(), "You're invited to " + competitionName, buildBody(competitionName, inviteUrl));
+        }
+        return invitationId;
+    }
+
+    private void sendInvitationEmail(long competitionId, long invitationId, String invitedEmail, HttpServletRequest request) throws SQLException {
+        CompetitionInvitationView invitation = repository.findInvitationById(invitationId);
+        CompetitionSummaryView competition = repository.findCompetition(competitionId);
+        if (invitation == null || competition == null || invitedEmail == null) {
+            return;
+        }
+        String inviteUrl = buildInvitationUrl(baseUrl(request), invitation.getToken());
+        emailService.sendInvitation(invitedEmail, "You're invited to " + competition.getName(), buildBody(competition.getName(), inviteUrl));
+    }
+
+    public String buildInvitationUrl(String baseUrl, String token) {
+        String root = baseUrl == null ? "" : baseUrl.replaceAll("/+$", "");
+        return root + "/invite?token=" + token;
+    }
+
+    private String baseUrl(HttpServletRequest request) {
+        if (request == null) {
+            return "";
+        }
+        StringBuilder builder = new StringBuilder();
+        builder.append(request.getScheme()).append("://").append(request.getServerName());
+        int port = request.getServerPort();
+        if (!("http".equalsIgnoreCase(request.getScheme()) && port == 80) && !("https".equalsIgnoreCase(request.getScheme()) && port == 443)) {
+            builder.append(":").append(port);
+        }
+        builder.append(request.getContextPath());
+        return builder.toString();
+    }
+
+    private long createSingleInvitation(long competitionId, String invitedEmail, String invitedUserId, String invitedByUserId) throws SQLException {
+        String token = randomToken();
+        Instant expiresAt = Instant.now().plus(14, ChronoUnit.DAYS);
+        return repository.createInvitation(competitionId, invitedEmail, invitedUserId, token, invitedByUserId, expiresAt);
+    }
+
+    private Map<String, String> splitEmails(String rawEmails) {
+        Map<String, String> emails = new LinkedHashMap<>();
+        if (rawEmails == null) {
+            return emails;
+        }
+        for (String part : EMAIL_SPLIT.split(rawEmails.trim())) {
+            String trimmed = part == null ? null : part.trim();
+            if (trimmed == null || trimmed.isBlank()) {
+                continue;
+            }
+            String normalized = normalizeEmail(trimmed);
+            if (normalized != null) {
+                emails.putIfAbsent(normalized, trimmed);
+            }
+        }
+        return emails;
+    }
+
+    private String normalizeEmail(String email) {
+        return email == null ? null : email.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private boolean isValidEmail(String email) {
+        return email != null && email.contains("@") && email.indexOf('@') > 0 && email.indexOf('@') < email.length() - 1;
+    }
+
+    private String randomToken() {
+        return UUID.randomUUID().toString().replace("-", "") + UUID.randomUUID().toString().replace("-", "");
+    }
+
+    private String buildBody(String competitionName, String inviteUrl) {
+        return "You have been invited to join " + competitionName + ".\n\nOpen this link to continue: " + inviteUrl;
+    }
+
+    public record InviteRecord(long invitationId, String invitedEmail, String invitedUserId) {}
+
+    public record InviteSubmissionResult(List<InviteRecord> createdInvites, List<String> errors) {}
+
+    public record InvitationDecisionResult(boolean success, String message) {
+        public static InvitationDecisionResult success(String message) { return new InvitationDecisionResult(true, message); }
+        public static InvitationDecisionResult error(String message) { return new InvitationDecisionResult(false, message); }
+    }
+}

--- a/src/main/java/com/frankies/bootcamp/service/CompetitionSetupService.java
+++ b/src/main/java/com/frankies/bootcamp/service/CompetitionSetupService.java
@@ -74,7 +74,7 @@ public class CompetitionSetupService {
         );
     }
 
-    public void createCompetitionAndJoin(BootcampAthlete athlete,
+    public long createCompetitionAndJoin(BootcampAthlete athlete,
                                          String competitionName,
                                          String timezone,
                                          String startDate,
@@ -94,8 +94,9 @@ public class CompetitionSetupService {
         Long endTimestamp = parseEndDate(endDate, resolvedTimezone, startTimestamp);
         double goal = parseStartingGoal(startingGoal, athlete.getGoal());
 
-        competitionRepository.createCompetitionWithAdmin(trimmedName, resolvedTimezone, startTimestamp, endTimestamp, athlete.getId(), goal);
+        long competitionId = competitionRepository.createCompetitionWithAdmin(trimmedName, resolvedTimezone, startTimestamp, endTimestamp, athlete.getId(), goal);
         athleteRefresh.refresh(athlete);
+        return competitionId;
     }
 
     public void joinCompetition(BootcampAthlete athlete,

--- a/src/main/java/com/frankies/bootcamp/service/DBService.java
+++ b/src/main/java/com/frankies/bootcamp/service/DBService.java
@@ -1007,6 +1007,19 @@ public class DBService {
         }
     }
 
+    public void leaveCompetition(long competitionId, String athleteId) throws SQLException {
+        try (
+                Connection connection = ds.getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "UPDATE competition_athlete SET status = 'left' WHERE competition_id = ? AND athlete_id = ? AND status = 'active'"
+                )
+        ) {
+            statement.setLong(1, competitionId);
+            statement.setString(2, athleteId);
+            statement.executeUpdate();
+        }
+    }
+
     public long ensureCompetitionAthlete(String athleteId, Double startingGoal) throws SQLException {
         try (
                 Connection connection = ds.getConnection();
@@ -1254,6 +1267,20 @@ public class DBService {
         }
     }
 
+    public int countCompetitionAdmins(long competitionId) throws SQLException {
+        try (
+                Connection connection = ds.getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT COUNT(*) FROM competition_athlete WHERE competition_id = ? AND role = 'admin' AND status = 'active'"
+                )
+        ) {
+            statement.setLong(1, competitionId);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                return resultSet.next() ? resultSet.getInt(1) : 0;
+            }
+        }
+    }
+
     public boolean hasActiveCompetitionInvitationForEmail(long competitionId, String normalizedEmail) throws SQLException {
         try (
                 Connection connection = ds.getConnection();
@@ -1378,7 +1405,15 @@ public class DBService {
         try (
                 Connection connection = ds.getConnection();
                 PreparedStatement statement = connection.prepareStatement(
-                        "SELECT ci.*, c.name AS competition_name FROM competition_invitation ci JOIN competitions c ON c.id = ci.competition_id WHERE ci.competition_id = ? AND ci.status = 'pending' ORDER BY ci.created_at DESC, ci.id DESC"
+                        "SELECT ci.*, c.name AS competition_name, " +
+                                "a.firstname AS invited_firstname, a.lastname AS invited_lastname, " +
+                                "u.display_name AS invited_display_name " +
+                                "FROM competition_invitation ci " +
+                                "JOIN competitions c ON c.id = ci.competition_id " +
+                                "LEFT JOIN app_users u ON u.id = ci.invited_user_id " +
+                                "LEFT JOIN athletes a ON a.user_id = u.id " +
+                                "WHERE ci.competition_id = ? AND ci.status = 'pending' " +
+                                "ORDER BY ci.created_at DESC, ci.id DESC"
                 )
         ) {
             statement.setLong(1, competitionId);
@@ -1399,7 +1434,14 @@ public class DBService {
         try (
                 Connection connection = ds.getConnection();
                 PreparedStatement statement = connection.prepareStatement(
-                        "SELECT ci.*, c.name AS competition_name FROM competition_invitation ci JOIN competitions c ON c.id = ci.competition_id WHERE ci.status = 'pending' AND (" +
+                        "SELECT ci.*, c.name AS competition_name, " +
+                                "a.firstname AS invited_firstname, a.lastname AS invited_lastname, " +
+                                "u.display_name AS invited_display_name " +
+                                "FROM competition_invitation ci " +
+                                "JOIN competitions c ON c.id = ci.competition_id " +
+                                "LEFT JOIN app_users u ON u.id = ci.invited_user_id " +
+                                "LEFT JOIN athletes a ON a.user_id = u.id " +
+                                "WHERE ci.status = 'pending' AND (" +
                                 "(ci.invited_user_id = ? AND ? IS NOT NULL) OR " +
                                 "(ci.invited_email_normalized = LOWER(?) AND ? IS NOT NULL) OR " +
                                 "(ci.invited_email_normalized = LOWER(?) AND ? IS NOT NULL)" +
@@ -2107,6 +2149,9 @@ public class DBService {
                 resultSet.getString("competition_name"),
                 resultSet.getString("invited_email"),
                 resultSet.getString("invited_user_id"),
+                resultSet.getString("invited_firstname"),
+                resultSet.getString("invited_lastname"),
+                resultSet.getString("invited_display_name"),
                 resultSet.getString("token"),
                 resultSet.getString("status"),
                 resultSet.getString("invited_by_user_id"),

--- a/src/main/java/com/frankies/bootcamp/service/DBService.java
+++ b/src/main/java/com/frankies/bootcamp/service/DBService.java
@@ -4,6 +4,9 @@ import com.frankies.bootcamp.model.BootcampAthlete;
 import com.frankies.bootcamp.model.AuthenticatedUser;
 import com.frankies.bootcamp.model.AthleteProfileBlurb;
 import com.frankies.bootcamp.model.EmailAccess;
+import com.frankies.bootcamp.model.CompetitionInviteCandidateView;
+import com.frankies.bootcamp.model.CompetitionInvitationStatus;
+import com.frankies.bootcamp.model.CompetitionInvitationView;
 import com.frankies.bootcamp.model.PerformanceResponse;
 import com.frankies.bootcamp.model.WeeklyPerformance;
 import com.frankies.bootcamp.model.CompetitionSummaryView;
@@ -191,6 +194,31 @@ public class DBService {
                             "CONSTRAINT fk_comp_honour_roll_comp FOREIGN KEY (competition_id) REFERENCES competitions(id) ON DELETE CASCADE" +
                             ")"
             );
+
+            statement.execute(
+                    "CREATE TABLE IF NOT EXISTS competition_invitation (" +
+                            "id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY, " +
+                            "competition_id BIGINT NOT NULL, " +
+                            "invited_email VARCHAR(255) NOT NULL, " +
+                            "invited_email_normalized VARCHAR(255) NOT NULL, " +
+                            "invited_user_id VARCHAR(50) NULL, " +
+                            "token VARCHAR(128) NOT NULL, " +
+                            "status VARCHAR(32) NOT NULL DEFAULT 'pending', " +
+                            "invited_by_user_id VARCHAR(50) NOT NULL, " +
+                            "created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, " +
+                            "updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, " +
+                            "expires_at TIMESTAMP NOT NULL, " +
+                            "accepted_at TIMESTAMP NULL, " +
+                            "declined_at TIMESTAMP NULL, " +
+                            "UNIQUE KEY uq_comp_invite_token (token), " +
+                            "UNIQUE KEY uq_comp_invite_email_status (competition_id, invited_email_normalized, status), " +
+                            "UNIQUE KEY uq_comp_invite_user_status (competition_id, invited_user_id, status), " +
+                            "INDEX idx_comp_invite_user (invited_user_id), " +
+                            "INDEX idx_comp_invite_competition (competition_id), " +
+                            "CONSTRAINT fk_comp_invite_comp FOREIGN KEY (competition_id) REFERENCES competitions(id) ON DELETE CASCADE, " +
+                            "CONSTRAINT fk_comp_invite_by_user FOREIGN KEY (invited_by_user_id) REFERENCES app_users(id)" +
+                            ")"
+            );
         }
     }
 
@@ -272,6 +300,7 @@ public class DBService {
         ) {
             ensureAthleteUserIdColumn(connection, statement);
             ensureAthleteSexColumn(connection, statement);
+            ensureAthleteProfileColumns(connection, statement);
             ensureNullableAppUserAthleteLink(connection, statement);
 
             statement.execute(
@@ -323,6 +352,24 @@ public class DBService {
     private void ensureAthleteSexColumn(Connection connection, Statement statement) throws SQLException {
         if (!columnExists(connection, "athletes", "sex")) {
             statement.execute("ALTER TABLE athletes ADD COLUMN sex VARCHAR(10) NULL");
+        }
+    }
+
+    private void ensureAthleteProfileColumns(Connection connection, Statement statement) throws SQLException {
+        if (!columnExists(connection, "athletes", "city")) {
+            statement.execute("ALTER TABLE athletes ADD COLUMN city VARCHAR(100) NULL");
+        }
+
+        if (!columnExists(connection, "athletes", "state")) {
+            statement.execute("ALTER TABLE athletes ADD COLUMN state VARCHAR(100) NULL");
+        }
+
+        if (!columnExists(connection, "athletes", "country")) {
+            statement.execute("ALTER TABLE athletes ADD COLUMN country VARCHAR(100) NULL");
+        }
+
+        if (!columnExists(connection, "athletes", "profile_medium")) {
+            statement.execute("ALTER TABLE athletes ADD COLUMN profile_medium VARCHAR(255) NULL");
         }
     }
 
@@ -448,6 +495,10 @@ public class DBService {
                 athlete.setFirstname(resultSet.getString("firstname"));
                 athlete.setEmail(resultSet.getString("email"));
                 athlete.setSex(resultSet.getString("sex"));
+                athlete.setCity(resultSet.getString("city"));
+                athlete.setState(resultSet.getString("state"));
+                athlete.setCountry(resultSet.getString("country"));
+                athlete.setProfileMedium(resultSet.getString("profile_medium"));
                 athlete.setGoal(resultSet.getDouble("start_goal"));
                 athlete.setSickWeeks(resultSet.getString("sick_week"));
                 user.add(athlete);
@@ -460,10 +511,10 @@ public class DBService {
         try (
                 Connection connection = ds.getConnection();
                 PreparedStatement statement = connection.prepareStatement("insert into athletes " +
-                        "(access_token, refresh_token, expires_at, token_type, expires_in, lastname, firstname, id, user_id, email, sex, start_goal)" +
-                        "values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) " +
+                        "(access_token, refresh_token, expires_at, token_type, expires_in, lastname, firstname, id, user_id, email, sex, city, state, country, profile_medium, start_goal)" +
+                        "values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) " +
                         "ON DUPLICATE KEY UPDATE " +
-                        "access_token=?, refresh_token=?, expires_at=?, token_type=?, expires_in=?, lastname=?, firstname=?, user_id=COALESCE(VALUES(user_id), user_id), email=COALESCE(VALUES(email), email), sex=COALESCE(VALUES(sex), sex), start_goal=COALESCE(VALUES(start_goal), start_goal)")
+                        "access_token=?, refresh_token=?, expires_at=?, token_type=?, expires_in=?, lastname=?, firstname=?, user_id=COALESCE(VALUES(user_id), user_id), email=COALESCE(VALUES(email), email), sex=COALESCE(VALUES(sex), sex), city=COALESCE(VALUES(city), city), state=COALESCE(VALUES(state), state), country=COALESCE(VALUES(country), country), profile_medium=COALESCE(VALUES(profile_medium), profile_medium), start_goal=COALESCE(VALUES(start_goal), start_goal)")
         ) {
             statement.setString(1, athlete.getAccessToken());
             statement.setString(2, athlete.getRefreshToken());
@@ -476,18 +527,22 @@ public class DBService {
             statement.setString(9, athlete.getUserId());
             statement.setString(10, athlete.getEmail());
             statement.setString(11, normaliseSex(athlete.getSex()));
+            statement.setString(12, athlete.getCity());
+            statement.setString(13, athlete.getState());
+            statement.setString(14, athlete.getCountry());
+            statement.setString(15, athlete.getProfileMedium());
             if (athlete.getGoal() == null) {
-                statement.setNull(12, java.sql.Types.DOUBLE);
+                statement.setNull(16, java.sql.Types.DOUBLE);
             } else {
-                statement.setDouble(12, athlete.getGoal());
+                statement.setDouble(16, athlete.getGoal());
             }
-            statement.setString(13, athlete.getAccessToken());
-            statement.setString(14, athlete.getRefreshToken());
-            statement.setLong(15, athlete.getExpiresAt());
-            statement.setString(16, athlete.getTokenType());
-            statement.setInt(17, athlete.getExpiresIn());
-            statement.setString(18, athlete.getLastname());
-            statement.setString(19, athlete.getFirstname());
+            statement.setString(17, athlete.getAccessToken());
+            statement.setString(18, athlete.getRefreshToken());
+            statement.setLong(19, athlete.getExpiresAt());
+            statement.setString(20, athlete.getTokenType());
+            statement.setInt(21, athlete.getExpiresIn());
+            statement.setString(22, athlete.getLastname());
+            statement.setString(23, athlete.getFirstname());
 
             statement.execute();
         }
@@ -1157,6 +1212,322 @@ public class DBService {
         return competitions;
     }
 
+    public CompetitionSummaryView findCompetitionSummary(long competitionId) throws SQLException {
+        try (
+                Connection connection = ds.getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT id, name, timezone, start_timestamp, end_timestamp, status FROM competitions WHERE id = ? LIMIT 1"
+                )
+        ) {
+            statement.setLong(1, competitionId);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (resultSet.next()) {
+                    return new CompetitionSummaryView(
+                            resultSet.getLong("id"),
+                            resultSet.getString("name"),
+                            resultSet.getString("timezone"),
+                            resultSet.getLong("start_timestamp"),
+                            getNullableLong(resultSet, "end_timestamp"),
+                            resultSet.getString("status")
+                    );
+                }
+            }
+        }
+        return null;
+    }
+
+    public boolean isCompetitionAdmin(long competitionId, String athleteId) throws SQLException {
+        if (athleteId == null || athleteId.isBlank()) {
+            return false;
+        }
+        try (
+                Connection connection = ds.getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT 1 FROM competition_athlete WHERE competition_id = ? AND athlete_id = ? AND role = 'admin' AND status = 'active' LIMIT 1"
+                )
+        ) {
+            statement.setLong(1, competitionId);
+            statement.setString(2, athleteId);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                return resultSet.next();
+            }
+        }
+    }
+
+    public boolean hasActiveCompetitionInvitationForEmail(long competitionId, String normalizedEmail) throws SQLException {
+        try (
+                Connection connection = ds.getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT 1 FROM competition_invitation WHERE competition_id = ? AND invited_email_normalized = ? AND status = 'pending' LIMIT 1"
+                )
+        ) {
+            statement.setLong(1, competitionId);
+            statement.setString(2, normalizedEmail);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                return resultSet.next();
+            }
+        }
+    }
+
+    public boolean hasActiveCompetitionInvitationForUser(long competitionId, String invitedUserId) throws SQLException {
+        if (invitedUserId == null || invitedUserId.isBlank()) {
+            return false;
+        }
+        try (
+                Connection connection = ds.getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT 1 FROM competition_invitation WHERE competition_id = ? AND invited_user_id = ? AND status = 'pending' LIMIT 1"
+                )
+        ) {
+            statement.setLong(1, competitionId);
+            statement.setString(2, invitedUserId);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                return resultSet.next();
+            }
+        }
+    }
+
+    public long createCompetitionInvitation(long competitionId,
+                                            String invitedEmail,
+                                            String invitedUserId,
+                                            String token,
+                                            String invitedByUserId,
+                                            Instant expiresAt) throws SQLException {
+        try (
+                Connection connection = ds.getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "INSERT INTO competition_invitation (competition_id, invited_email, invited_email_normalized, invited_user_id, token, status, invited_by_user_id, expires_at) VALUES (?, ?, ?, ?, ?, 'pending', ?, ?)",
+                        Statement.RETURN_GENERATED_KEYS
+                )
+        ) {
+            statement.setLong(1, competitionId);
+            statement.setString(2, invitedEmail);
+            statement.setString(3, invitedEmail == null ? null : invitedEmail.toLowerCase(java.util.Locale.ROOT));
+            if (invitedUserId == null || invitedUserId.isBlank()) {
+                statement.setNull(4, java.sql.Types.VARCHAR);
+            } else {
+                statement.setString(4, invitedUserId);
+            }
+            statement.setString(5, token);
+            statement.setString(6, invitedByUserId);
+            statement.setTimestamp(7, Timestamp.from(expiresAt));
+            statement.executeUpdate();
+            try (ResultSet resultSet = statement.getGeneratedKeys()) {
+                if (resultSet.next()) {
+                    return resultSet.getLong(1);
+                }
+            }
+        }
+        throw new SQLException("Unable to create competition invitation");
+    }
+
+    public CompetitionInvitationView findCompetitionInvitationByToken(String token) throws SQLException {
+        try (
+                Connection connection = ds.getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT ci.*, c.name AS competition_name FROM competition_invitation ci JOIN competitions c ON c.id = ci.competition_id WHERE ci.token = ? LIMIT 1"
+                )
+        ) {
+            statement.setString(1, token);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (resultSet.next()) {
+                    return mapInvitation(resultSet);
+                }
+            }
+        }
+        return null;
+    }
+
+    public CompetitionInvitationView findCompetitionInvitationByCompetitionAndToken(long competitionId, String token) throws SQLException {
+        try (
+                Connection connection = ds.getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT ci.*, c.name AS competition_name FROM competition_invitation ci JOIN competitions c ON c.id = ci.competition_id WHERE ci.competition_id = ? AND ci.token = ? LIMIT 1"
+                )
+        ) {
+            statement.setLong(1, competitionId);
+            statement.setString(2, token);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (resultSet.next()) {
+                    return mapInvitation(resultSet);
+                }
+            }
+        }
+        return null;
+    }
+
+    public CompetitionInvitationView findCompetitionInvitationById(long invitationId) throws SQLException {
+        try (
+                Connection connection = ds.getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT ci.*, c.name AS competition_name FROM competition_invitation ci JOIN competitions c ON c.id = ci.competition_id WHERE ci.id = ? LIMIT 1"
+                )
+        ) {
+            statement.setLong(1, invitationId);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (resultSet.next()) {
+                    return mapInvitation(resultSet);
+                }
+            }
+        }
+        return null;
+    }
+
+    public List<CompetitionInvitationView> listPendingCompetitionInvitationsForCompetition(long competitionId) throws SQLException {
+        List<CompetitionInvitationView> invitations = new ArrayList<>();
+        try (
+                Connection connection = ds.getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT ci.*, c.name AS competition_name FROM competition_invitation ci JOIN competitions c ON c.id = ci.competition_id WHERE ci.competition_id = ? AND ci.status = 'pending' ORDER BY ci.created_at DESC, ci.id DESC"
+                )
+        ) {
+            statement.setLong(1, competitionId);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                while (resultSet.next()) {
+                    invitations.add(mapInvitation(resultSet));
+                }
+            }
+        }
+        return invitations;
+    }
+
+    public List<CompetitionInvitationView> listPendingCompetitionInvitationsForUser(String userId, String email, String athleteId) throws SQLException {
+        List<CompetitionInvitationView> invitations = new ArrayList<>();
+        if ((userId == null || userId.isBlank()) && (email == null || email.isBlank()) && (athleteId == null || athleteId.isBlank())) {
+            return invitations;
+        }
+        try (
+                Connection connection = ds.getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT ci.*, c.name AS competition_name FROM competition_invitation ci JOIN competitions c ON c.id = ci.competition_id WHERE ci.status = 'pending' AND (" +
+                                "(ci.invited_user_id = ? AND ? IS NOT NULL) OR " +
+                                "(ci.invited_email_normalized = LOWER(?) AND ? IS NOT NULL) OR " +
+                                "(ci.invited_email_normalized = LOWER(?) AND ? IS NOT NULL)" +
+                                ") ORDER BY ci.created_at DESC, ci.id DESC"
+                )
+        ) {
+            statement.setString(1, userId);
+            statement.setString(2, userId);
+            statement.setString(3, email);
+            statement.setString(4, email);
+            statement.setString(5, athleteId);
+            statement.setString(6, athleteId);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                while (resultSet.next()) {
+                    invitations.add(mapInvitation(resultSet));
+                }
+            }
+        }
+        return invitations;
+    }
+
+    public List<CompetitionInviteCandidateView> searchCompetitionInviteCandidates(long competitionId, String query) throws SQLException {
+        List<CompetitionInviteCandidateView> candidates = new ArrayList<>();
+        String normalizedQuery = query == null ? "" : query.trim().toLowerCase(java.util.Locale.ROOT);
+        if (normalizedQuery.isBlank()) {
+            return candidates;
+        }
+        try (
+                Connection connection = ds.getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT DISTINCT u.id AS user_id, a.id AS athlete_id, u.display_name, u.email, a.profile_medium, a.firstname, a.lastname, a.city, a.state, a.country, " +
+                                "EXISTS(SELECT 1 FROM competition_athlete ca WHERE ca.competition_id = ? AND ca.athlete_id = a.id AND ca.status = 'active') AS already_in_competition " +
+                                "FROM app_users u " +
+                                "LEFT JOIN athletes a ON a.user_id = u.id OR (a.email IS NOT NULL AND LOWER(a.email) = LOWER(u.email)) " +
+                                "WHERE (LOWER(u.display_name) LIKE ? OR LOWER(COALESCE(a.firstname, '')) LIKE ? OR LOWER(COALESCE(a.lastname, '')) LIKE ?) " +
+                                "AND NOT EXISTS (SELECT 1 FROM competition_athlete ca2 WHERE ca2.competition_id = ? AND ca2.athlete_id = a.id AND ca2.status = 'active') " +
+                                "ORDER BY already_in_competition ASC, COALESCE(u.display_name, CONCAT(a.firstname, ' ', a.lastname)) ASC"
+                )
+        ) {
+            String like = "%" + normalizedQuery + "%";
+            statement.setLong(1, competitionId);
+            statement.setString(2, like);
+            statement.setString(3, like);
+            statement.setString(4, like);
+            statement.setLong(5, competitionId);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                while (resultSet.next()) {
+                    String displayName = resultSet.getString("display_name");
+                    if (displayName == null || displayName.isBlank()) {
+                        displayName = (resultSet.getString("firstname") == null ? "" : resultSet.getString("firstname"))
+                                + " "
+                                + (resultSet.getString("lastname") == null ? "" : resultSet.getString("lastname"));
+                        displayName = displayName.trim();
+                    }
+                    candidates.add(new CompetitionInviteCandidateView(
+                            resultSet.getString("user_id"),
+                            resultSet.getString("athlete_id"),
+                            displayName,
+                            resultSet.getString("email"),
+                            resultSet.getString("profile_medium"),
+                            resultSet.getString("city"),
+                            resultSet.getString("state"),
+                            resultSet.getString("country"),
+                            resultSet.getBoolean("already_in_competition")
+                    ));
+                }
+            }
+        }
+        return candidates;
+    }
+
+    public void acceptCompetitionInvitation(long invitationId, String athleteId, double startingGoal) throws SQLException {
+        try (Connection connection = ds.getConnection()) {
+            connection.setAutoCommit(false);
+            try {
+                CompetitionInvitationView invitation = findCompetitionInvitationById(invitationId);
+                if (invitation == null) {
+                    throw new SQLException("Invitation not found");
+                }
+                try (PreparedStatement statement = connection.prepareStatement(
+                        "INSERT INTO competition_athlete (competition_id, athlete_id, role, starting_goal, status) VALUES (?, ?, 'member', ?, 'active') " +
+                                "ON DUPLICATE KEY UPDATE status = 'active', starting_goal = VALUES(starting_goal)"
+                )) {
+                    statement.setLong(1, invitation.getCompetitionId());
+                    statement.setString(2, athleteId);
+                    statement.setDouble(3, startingGoal);
+                    statement.executeUpdate();
+                }
+                try (PreparedStatement statement = connection.prepareStatement(
+                        "UPDATE competition_invitation SET status = 'accepted', accepted_at = CURRENT_TIMESTAMP WHERE id = ?"
+                )) {
+                    statement.setLong(1, invitationId);
+                    statement.executeUpdate();
+                }
+                connection.commit();
+            } catch (SQLException e) {
+                connection.rollback();
+                throw e;
+            } finally {
+                connection.setAutoCommit(true);
+            }
+        }
+    }
+
+    public void declineCompetitionInvitation(long invitationId) throws SQLException {
+        try (
+                Connection connection = ds.getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "UPDATE competition_invitation SET status = 'declined', declined_at = CURRENT_TIMESTAMP WHERE id = ? AND status = 'pending'"
+                )
+        ) {
+            statement.setLong(1, invitationId);
+            statement.executeUpdate();
+        }
+    }
+
+    public void expireCompetitionInvitation(long invitationId) throws SQLException {
+        try (
+                Connection connection = ds.getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "UPDATE competition_invitation SET status = 'expired' WHERE id = ? AND status = 'pending'"
+                )
+        ) {
+            statement.setLong(1, invitationId);
+            statement.executeUpdate();
+        }
+    }
+
     public boolean athleteBelongsToCompetition(String athleteId, long competitionId) throws SQLException {
         try (
                 Connection connection = ds.getConnection();
@@ -1719,9 +2090,32 @@ public class DBService {
         return resultSet.wasNull() ? null : value;
     }
 
+    private Instant getNullableInstant(ResultSet resultSet, String columnName) throws SQLException {
+        Timestamp timestamp = resultSet.getTimestamp(columnName);
+        return timestamp == null ? null : timestamp.toInstant();
+    }
+
     private Long getNullableLong(ResultSet resultSet, String columnName) throws SQLException {
         long value = resultSet.getLong(columnName);
         return resultSet.wasNull() ? null : value;
+    }
+
+    private CompetitionInvitationView mapInvitation(ResultSet resultSet) throws SQLException {
+        return new CompetitionInvitationView(
+                resultSet.getLong("id"),
+                resultSet.getLong("competition_id"),
+                resultSet.getString("competition_name"),
+                resultSet.getString("invited_email"),
+                resultSet.getString("invited_user_id"),
+                resultSet.getString("token"),
+                resultSet.getString("status"),
+                resultSet.getString("invited_by_user_id"),
+                getNullableInstant(resultSet, "created_at"),
+                getNullableInstant(resultSet, "updated_at"),
+                getNullableInstant(resultSet, "expires_at"),
+                getNullableInstant(resultSet, "accepted_at"),
+                getNullableInstant(resultSet, "declined_at")
+        );
     }
 
     private void deletePersistentCompetitionDerivedState(Connection connection, long competitionAthleteId) throws SQLException {

--- a/src/main/java/com/frankies/bootcamp/service/StravaService.java
+++ b/src/main/java/com/frankies/bootcamp/service/StravaService.java
@@ -118,6 +118,47 @@ public class StravaService {
         return null;
     }
 
+    public BootcampAthlete backfillAthleteProfileIfMissing(BootcampAthlete athlete) throws CredentialStoreException, NoSuchAlgorithmException, IOException, SQLException {
+        if (athlete == null || !isProfileBackfillRequired(athlete) || athlete.getAccessToken() == null || athlete.getAccessToken().isBlank()) {
+            return athlete;
+        }
+
+        BootcampAthlete refreshedAthlete = refreshToken(athlete);
+        StravaAuthResponse.Athlete stravaAthlete = fetchCurrentAthleteProfile(refreshedAthlete.getAccessToken());
+        if (stravaAthlete == null) {
+            return refreshedAthlete;
+        }
+
+        boolean changed = applyProfileDetails(refreshedAthlete, stravaAthlete);
+        if (changed) {
+            db.saveAthlete(refreshedAthlete);
+        }
+        return refreshedAthlete;
+    }
+
+    public StravaAuthResponse.Athlete fetchCurrentAthleteProfile(String bearer) throws IOException {
+        OkHttpClient client = new OkHttpClient().newBuilder().build();
+        Request request = new Request.Builder()
+                .url("https://www.strava.com/api/v3/athlete")
+                .method("GET", null)
+                .addHeader("Authorization", "Bearer " + bearer)
+                .build();
+
+        try (Response response = client.newCall(request).execute()) {
+            String body = response.body() == null ? "" : response.body().string();
+            if (response.isSuccessful()) {
+                try {
+                    return new Gson().fromJson(body, StravaAuthResponse.Athlete.class);
+                } catch (RuntimeException e) {
+                    throw new IOException("Unable to parse Strava athlete profile", e);
+                }
+            }
+
+            log.warn("StravaService: failed to fetch athlete profile. Code: {} Body: {}", response.code(), body);
+            throw new IOException("Strava athlete profile fetch failed, HTTP " + response.code());
+        }
+    }
+
     public BootcampAthlete refreshToken(BootcampAthlete athlete) throws CredentialStoreException, NoSuchAlgorithmException, IOException, SQLException {
         Instant expiry = Instant.ofEpochSecond(athlete.getExpiresAt());
         if (Instant.now().isAfter(expiry.minusSeconds(60))) {
@@ -230,6 +271,34 @@ public class StravaService {
             log.error("StravaService: unexpected error fetching activity " + activityId, e);
             throw new IOException(e);
         }
+    }
+
+    private boolean isProfileBackfillRequired(BootcampAthlete athlete) {
+        return isBlank(athlete.getCity())
+                || isBlank(athlete.getState())
+                || isBlank(athlete.getCountry())
+                || isBlank(athlete.getProfileMedium());
+    }
+
+    private boolean applyProfileDetails(BootcampAthlete target, StravaAuthResponse.Athlete source) {
+        boolean changed = false;
+        changed |= setIfBlank(target.getCity(), source.getCity(), target::setCity);
+        changed |= setIfBlank(target.getState(), source.getState(), target::setState);
+        changed |= setIfBlank(target.getCountry(), source.getCountry(), target::setCountry);
+        changed |= setIfBlank(target.getProfileMedium(), source.getProfile_medium(), target::setProfileMedium);
+        return changed;
+    }
+
+    private boolean setIfBlank(String existing, String incoming, java.util.function.Consumer<String> setter) {
+        if (!isBlank(existing) || isBlank(incoming)) {
+            return false;
+        }
+        setter.accept(incoming.trim());
+        return true;
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
     }
 
 

--- a/src/main/java/com/frankies/bootcamp/servlet/AppServlet.java
+++ b/src/main/java/com/frankies/bootcamp/servlet/AppServlet.java
@@ -3,16 +3,20 @@ package com.frankies.bootcamp.servlet;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.jboss.logging.Logger;
 
 import java.io.IOException;
 
 @WebServlet(name = "appHome", value = "/app")
 public class AppServlet extends BootcampServlet {
+    private static final Logger log = Logger.getLogger(AppServlet.class);
+
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
         try {
             req.getRequestDispatcher("/app/index.jsp").forward(req, resp);
         } catch (jakarta.servlet.ServletException e) {
+            log.error("Unable to render app home", e);
             throw new IOException("Unable to render app home", e);
         }
     }

--- a/src/main/java/com/frankies/bootcamp/servlet/AthleteHistoryServlet.java
+++ b/src/main/java/com/frankies/bootcamp/servlet/AthleteHistoryServlet.java
@@ -3,6 +3,7 @@ package com.frankies.bootcamp.servlet;
 import com.frankies.bootcamp.model.WeeklyPerformance;
 import com.frankies.bootcamp.model.CompetitionSummaryView;
 import com.frankies.bootcamp.service.ActivityProcessFacade;
+import com.frankies.bootcamp.service.AuthSessionService;
 import com.frankies.bootcamp.utils.DateTimeUtils;
 import jakarta.inject.Inject;
 import jakarta.servlet.annotation.WebServlet;
@@ -37,6 +38,8 @@ public class AthleteHistoryServlet extends BootcampServlet {
     @Inject
     private ActivityProcessFacade activityProcessFacade;
     @Inject
+    private AuthSessionService authSessionService;
+    @Inject
     private AiMessageService aiMessageService;
 
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -56,6 +59,7 @@ public class AthleteHistoryServlet extends BootcampServlet {
         }
         CompetitionSummaryView selectedCompetition = findSelectedCompetition(request, selectedCompetitionId);
         boolean selectedCompetitionIsCurrent = selectedCompetitionId == null || isCurrentCompetition(request, selectedCompetitionId);
+        boolean hideMotivationalMessage = authSessionService.isHistoryMotivationalMessageHidden(request);
         if (history.isEmpty() || selectedActiveCompetitionHistoryIsStale(history, selectedCompetition, selectedCompetitionIsCurrent)) {
             try {
                 if (selectedCompetitionId == null) {
@@ -130,23 +134,18 @@ public class AthleteHistoryServlet extends BootcampServlet {
             String favouriteSports = com.frankies.bootcamp.sport.SportsUtils.getFavouriteSports(sports, 2);
             String suggestedSport = com.frankies.bootcamp.sport.SportsUtils.getSuggestedSport(sports.keySet());
 
-            String aiMsg = selectedCompetitionIsCurrent
-                    ? aiMessageService.getMotivationalMessage(
-                            athleteName, distance, goal, hitGoal, leaderboardRank, favouriteSports, suggestedSport
-                    )
-                    : aiMessageService.getCompetitionRecapMessage(
-                            athleteName,
-                            selectedCompetition == null ? null : selectedCompetition.getName(),
-                            displayWeekCount,
-                            totalDistance(history),
-                            totalScore(history),
-                            leaderboardRank,
-                            favouriteSports
-                    );
-            out.println("<div class='alert alert-info alert-dismissible fade show history-subheading' style='margin-bottom:1em;' role='alert'>");
-            out.println(aiMsg);
-            out.println("<button type='button' class='btn-close' data-bs-dismiss='alert' aria-label='Dismiss ZenBot message'></button>");
-            out.println("</div>");
+            if (selectedCompetitionIsCurrent && !hideMotivationalMessage) {
+                String aiMsg = aiMessageService.getMotivationalMessage(
+                        athleteName, distance, goal, hitGoal, leaderboardRank, favouriteSports, suggestedSport
+                );
+                out.println("<div class='alert alert-info history-subheading d-flex justify-content-between align-items-start gap-3' style='margin-bottom:1em;' role='alert'>");
+                out.println("<div>" + aiMsg + "</div>");
+                out.println("<form method='post' action='" + request.getContextPath() + "/app/AthleteHistory' class='m-0'>");
+                out.println("<input type='hidden' name='action' value='hideMotivationalMessage'>");
+                out.println("<button type='submit' class='btn-close' aria-label='Dismiss ZenBot message'></button>");
+                out.println("</form>");
+                out.println("</div>");
+            }
         }
         out.println("<div class='table-responsive mt-4'>");
         out.println("<table class='table table-bordered table-striped align-middle'>");
@@ -224,6 +223,15 @@ public class AthleteHistoryServlet extends BootcampServlet {
         out.println("</div>");
         out.println("</div>");
         out.println("</body></html>");
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        String action = request.getParameter("action");
+        if ("hideMotivationalMessage".equals(action)) {
+            authSessionService.hideHistoryMotivationalMessage(request);
+        }
+        response.sendRedirect(request.getContextPath() + "/app/");
     }
 
     private static boolean isCurrentCompetition(HttpServletRequest request, Long selectedCompetitionId) {

--- a/src/main/java/com/frankies/bootcamp/servlet/AthleteHistoryServlet.java
+++ b/src/main/java/com/frankies/bootcamp/servlet/AthleteHistoryServlet.java
@@ -81,9 +81,6 @@ public class AthleteHistoryServlet extends BootcampServlet {
         int latestHistoryWeek = history.keySet().stream().mapToInt(Integer::intValue).max().orElse(numberOfWeeksSinceStart);
         int displayWeekCount = selectedCompetitionId == null ? numberOfWeeksSinceStart : latestHistoryWeek;
 
-        out.println("<html><head>");
-        out.println("</head><body>");
-
         out.println("<div class='container'>");
 
         out.println("<h2 class='history-heading'>");
@@ -97,9 +94,12 @@ public class AthleteHistoryServlet extends BootcampServlet {
         if (history.isEmpty()) {
             out.println("<div class='alert alert-info'>We are getting things ready for your Strava account. Your history should appear shortly.</div>");
             out.println("</div>");
-            out.println("</body></html>");
             return;
         }
+
+        List<Integer> weekNumbers = history.keySet().stream()
+                .sorted()
+                .toList();
 
         WeeklyPerformance latest = history.get(displayWeekCount);
         if (latest != null) {
@@ -221,8 +221,29 @@ public class AthleteHistoryServlet extends BootcampServlet {
         out.println("</tbody>");
         out.println("</table>");
         out.println("</div>");
+
+        out.println("<script>");
+        out.println("(function () {");
+        out.println("const cards = Array.from(document.querySelectorAll('[data-history-week-index]'));");
+        out.println("const select = document.getElementById('historyWeekSelect');");
+        out.println("const prev = document.getElementById('historyWeekPrevBtn');");
+        out.println("const next = document.getElementById('historyWeekNextBtn');");
+        out.println("if (!cards.length || !select || !prev || !next) { return; }");
+        out.println("let currentIndex = 0;");
+        out.println("function showWeek(index) {");
+        out.println("  currentIndex = Math.max(0, Math.min(cards.length - 1, index));");
+        out.println("  cards.forEach(function (card, cardIndex) { card.classList.toggle('d-none', cardIndex !== currentIndex); });");
+        out.println("  select.value = String(currentIndex);");
+        out.println("  prev.disabled = currentIndex === 0;");
+        out.println("  next.disabled = currentIndex === cards.length - 1;");
+        out.println("}");
+        out.println("select.addEventListener('change', function () { showWeek(parseInt(select.value, 10)); });");
+        out.println("prev.addEventListener('click', function () { showWeek(currentIndex - 1); });");
+        out.println("next.addEventListener('click', function () { showWeek(currentIndex + 1); });");
+        out.println("showWeek(cards.length - 1);");
+        out.println("})();");
+        out.println("</script>");
         out.println("</div>");
-        out.println("</body></html>");
     }
 
     @Override
@@ -344,5 +365,23 @@ public class AthleteHistoryServlet extends BootcampServlet {
         }
         html.append("</details>");
         return html.toString();
+    }
+
+    private static void mobileMetric(PrintWriter out, String label, String value) {
+        out.println("<div class='col'>");
+        out.println("<div class='history-mobile-metric card h-100 border-0 bg-light-subtle shadow-sm'>");
+        out.println("<div class='card-body p-2'>");
+        out.println("<div class='text-muted small text-uppercase fw-semibold mb-1'>" + label + "</div>");
+        out.println("<div class='fw-semibold lh-sm'>" + value + "</div>");
+        out.println("</div>");
+        out.println("</div>");
+        out.println("</div>");
+    }
+
+    private static String prettyWeekLabel(String weekLabel) {
+        if (weekLabel == null) {
+            return "";
+        }
+        return weekLabel.replaceAll("([A-Za-z]+)(\\d+)", "$1 $2");
     }
 }

--- a/src/main/java/com/frankies/bootcamp/servlet/AthleteSummaryServlet.java
+++ b/src/main/java/com/frankies/bootcamp/servlet/AthleteSummaryServlet.java
@@ -1,6 +1,7 @@
 package com.frankies.bootcamp.servlet;
 
 import com.frankies.bootcamp.service.ActivityProcessFacade;
+import com.frankies.bootcamp.model.CompetitionSummaryView;
 import com.frankies.bootcamp.utils.WildflyUtils;
 import jakarta.inject.Inject;
 import jakarta.servlet.annotation.WebServlet;
@@ -12,6 +13,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.security.NoSuchAlgorithmException;
 import java.sql.SQLException;
+import java.util.List;
 
 @WebServlet(name = "athleteSummary", value = "/app/AthleteSummary")
 public class AthleteSummaryServlet extends BootcampServlet {
@@ -21,10 +23,11 @@ public class AthleteSummaryServlet extends BootcampServlet {
         response.setContentType("text/html");
         PrintWriter out = response.getWriter();
         String summaryContent = "";
+        Long selectedCompetitionId = null;
 
         try {
             com.frankies.bootcamp.model.BootcampAthlete loggedInAthlete = (com.frankies.bootcamp.model.BootcampAthlete) request.getAttribute("athlete");
-            Long selectedCompetitionId = (Long) request.getAttribute("selectedCompetitionId");
+            selectedCompetitionId = (Long) request.getAttribute("selectedCompetitionId");
             summaryContent = selectedCompetitionId != null
                     ? activityProcessFacade.getLoggedInAthleteSummaryForCompetition(selectedCompetitionId, loggedInAthlete.getId())
                     : activityProcessFacade.getLoggedInAthleteSummary(loggedInAthlete.getId());
@@ -42,7 +45,8 @@ public class AthleteSummaryServlet extends BootcampServlet {
         out.println("<body>");
         out.println("  <div class=\"container\">");
 
-        // Optional: Add trophy icon before the summary content block
+        renderCompetitionSwitcher(request, out, selectedCompetitionId);
+
         out.println("    <p><i class=\"bi bi-trophy-fill trophy-icon\"></i><strong>Performance Summary:</strong></p>");
 
         // Output escaped or raw summaryContent depending on its nature
@@ -57,5 +61,58 @@ public class AthleteSummaryServlet extends BootcampServlet {
         out.println("  </div>");
         out.println("</body>");
         out.println("</html>");
+    }
+
+    private void renderCompetitionSwitcher(HttpServletRequest request, PrintWriter out, Long selectedCompetitionId) {
+        List<CompetitionSummaryView> activeCompetitions = competitions(request, "activeCompetitions");
+        List<CompetitionSummaryView> pastCompetitions = competitions(request, "pastCompetitions");
+        if ((activeCompetitions == null || activeCompetitions.isEmpty()) && (pastCompetitions == null || pastCompetitions.isEmpty())) {
+            return;
+        }
+
+        out.println("    <div class=\"card shadow-sm border-0 mb-3\">");
+        out.println("      <div class=\"card-body py-3\">");
+        out.println("        <form class=\"row g-2 align-items-end\" method=\"get\" action=\"" + request.getContextPath() + "/app/select-competition\">");
+        out.println("          <input type=\"hidden\" name=\"returnTo\" value=\"/app/\">");
+        out.println("          <div class=\"col-md-9\">");
+        out.println("            <label class=\"form-label mb-1\" for=\"competitionId\">Switch competition</label>");
+        out.println("            <select class=\"form-select\" id=\"competitionId\" name=\"competitionId\">");
+        if (activeCompetitions != null && !activeCompetitions.isEmpty()) {
+            out.println("              <optgroup label=\"Current competitions\">");
+            for (CompetitionSummaryView competition : activeCompetitions) {
+                out.println(renderCompetitionOption(competition, selectedCompetitionId));
+            }
+            out.println("              </optgroup>");
+        }
+        if (pastCompetitions != null && !pastCompetitions.isEmpty()) {
+            out.println("              <optgroup label=\"Past competitions\">");
+            for (CompetitionSummaryView competition : pastCompetitions) {
+                out.println(renderCompetitionOption(competition, selectedCompetitionId));
+            }
+            out.println("              </optgroup>");
+        }
+        out.println("            </select>");
+        out.println("          </div>");
+        out.println("          <div class=\"col-md-3 d-grid\">");
+        out.println("            <button class=\"btn btn-outline-primary\" type=\"submit\">Open</button>");
+        out.println("          </div>");
+        out.println("        </form>");
+        out.println("      </div>");
+        out.println("    </div>");
+    }
+
+    private List<CompetitionSummaryView> competitions(HttpServletRequest request, String attributeName) {
+        Object competitionsAttr = request.getAttribute(attributeName);
+        if (competitionsAttr instanceof List<?> list) {
+            @SuppressWarnings("unchecked")
+            List<CompetitionSummaryView> cast = (List<CompetitionSummaryView>) list;
+            return cast;
+        }
+        return List.of();
+    }
+
+    private String renderCompetitionOption(CompetitionSummaryView competition, Long selectedCompetitionId) {
+        boolean selected = selectedCompetitionId != null && selectedCompetitionId == competition.getId();
+        return "              <option value=\"" + competition.getId() + "\"" + (selected ? " selected" : "") + ">" + WildflyUtils.escape(competition.getName()) + "</option>";
     }
 }

--- a/src/main/java/com/frankies/bootcamp/servlet/AthleteSummaryServlet.java
+++ b/src/main/java/com/frankies/bootcamp/servlet/AthleteSummaryServlet.java
@@ -1,118 +1,71 @@
 package com.frankies.bootcamp.servlet;
 
 import com.frankies.bootcamp.service.ActivityProcessFacade;
-import com.frankies.bootcamp.model.CompetitionSummaryView;
-import com.frankies.bootcamp.utils.WildflyUtils;
+import com.frankies.bootcamp.model.BootcampAthlete;
 import jakarta.inject.Inject;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.jboss.logging.Logger;
 import org.wildfly.security.credential.store.CredentialStoreException;
 
 import java.io.IOException;
-import java.io.PrintWriter;
 import java.security.NoSuchAlgorithmException;
 import java.sql.SQLException;
-import java.util.List;
 
 @WebServlet(name = "athleteSummary", value = "/app/AthleteSummary")
 public class AthleteSummaryServlet extends BootcampServlet {
+    private static final Logger log = Logger.getLogger(AthleteSummaryServlet.class);
+
     @Inject
     private ActivityProcessFacade activityProcessFacade;
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        response.setContentType("text/html");
-        PrintWriter out = response.getWriter();
-        String summaryContent = "";
-        Long selectedCompetitionId = null;
-
         try {
-            com.frankies.bootcamp.model.BootcampAthlete loggedInAthlete = (com.frankies.bootcamp.model.BootcampAthlete) request.getAttribute("athlete");
-            selectedCompetitionId = (Long) request.getAttribute("selectedCompetitionId");
-            summaryContent = selectedCompetitionId != null
+            BootcampAthlete loggedInAthlete = (BootcampAthlete) request.getAttribute("athlete");
+            if (loggedInAthlete == null || loggedInAthlete.getId() == null || loggedInAthlete.getId().isBlank()) {
+                response.sendError(HttpServletResponse.SC_BAD_REQUEST, "A linked athlete is required.");
+                return;
+            }
+            if (activityProcessFacade == null) {
+                throw new IllegalStateException("ActivityProcessFacade was not available.");
+            }
+            Long selectedCompetitionId = resolveSelectedCompetitionId(request);
+            String summaryContent = selectedCompetitionId != null
                     ? activityProcessFacade.getLoggedInAthleteSummaryForCompetition(selectedCompetitionId, loggedInAthlete.getId())
                     : activityProcessFacade.getLoggedInAthleteSummary(loggedInAthlete.getId());
-        } catch (IOException | CredentialStoreException | NoSuchAlgorithmException | SQLException e) {
+            request.setAttribute("summaryContent", summaryContent);
+            request.setAttribute("summaryError", null);
+            request.getRequestDispatcher("/app/athlete-summary.jsp").forward(request, response);
+        } catch (IOException | CredentialStoreException | NoSuchAlgorithmException | SQLException | jakarta.servlet.ServletException e) {
+            log.error("Failed to load athlete summary", e);
+            renderFallback(request, response, e);
+        } catch (RuntimeException e) {
+            log.error("Failed to load athlete summary", e);
+            renderFallback(request, response, e);
+        }
+    }
+
+    private Long resolveSelectedCompetitionId(HttpServletRequest request) {
+        Object selectedCompetitionId = request.getAttribute("selectedCompetitionId");
+        if (selectedCompetitionId instanceof Long competitionId) {
+            return competitionId;
+        }
+        if (selectedCompetitionId instanceof String competitionIdText && !competitionIdText.isBlank()) {
+            return Long.parseLong(competitionIdText);
+        }
+        return null;
+    }
+
+    private void renderFallback(HttpServletRequest request, HttpServletResponse response, Exception error) throws IOException {
+        if (response.isCommitted()) {
+            throw new IOException("Failed to load athlete summary", error);
+        }
+        request.setAttribute("summaryContent", "Summary unavailable right now.");
+        request.setAttribute("summaryError", "Could not load your summary right now.");
+        try {
+            request.getRequestDispatcher("/app/athlete-summary.jsp").forward(request, response);
+        } catch (jakarta.servlet.ServletException e) {
             throw new IOException("Failed to load athlete summary", e);
         }
-
-        out.println("<!DOCTYPE html>");
-        out.println("<html lang=\"en\">");
-        out.println("<head>");
-        out.println("  <meta charset=\"UTF-8\">");
-        out.println("  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">");
-        out.println("  <title>Athlete Summary</title>");
-        out.println("</head>");
-        out.println("<body>");
-        out.println("  <div class=\"container\">");
-
-        renderCompetitionSwitcher(request, out, selectedCompetitionId);
-
-        out.println("    <p><i class=\"bi bi-trophy-fill trophy-icon\"></i><strong>Performance Summary:</strong></p>");
-
-        // Output escaped or raw summaryContent depending on its nature
-        out.println("    <div class=\"mt-2\">");
-        out.println(WildflyUtils.escape(summaryContent));
-        out.println("    </div>");
-
-        // Optional: Add another trophy or reward footer
-        out.println("    <hr/>");
-        out.println("    <p class=\"text-muted\"><i class=\"bi bi-award-fill text-warning\"></i> Keep training hard and breaking limits!</p>");
-
-        out.println("  </div>");
-        out.println("</body>");
-        out.println("</html>");
-    }
-
-    private void renderCompetitionSwitcher(HttpServletRequest request, PrintWriter out, Long selectedCompetitionId) {
-        List<CompetitionSummaryView> activeCompetitions = competitions(request, "activeCompetitions");
-        List<CompetitionSummaryView> pastCompetitions = competitions(request, "pastCompetitions");
-        if ((activeCompetitions == null || activeCompetitions.isEmpty()) && (pastCompetitions == null || pastCompetitions.isEmpty())) {
-            return;
-        }
-
-        out.println("    <div class=\"card shadow-sm border-0 mb-3\">");
-        out.println("      <div class=\"card-body py-3\">");
-        out.println("        <form class=\"row g-2 align-items-end\" method=\"get\" action=\"" + request.getContextPath() + "/app/select-competition\">");
-        out.println("          <input type=\"hidden\" name=\"returnTo\" value=\"/app/\">");
-        out.println("          <div class=\"col-md-9\">");
-        out.println("            <label class=\"form-label mb-1\" for=\"competitionId\">Switch competition</label>");
-        out.println("            <select class=\"form-select\" id=\"competitionId\" name=\"competitionId\">");
-        if (activeCompetitions != null && !activeCompetitions.isEmpty()) {
-            out.println("              <optgroup label=\"Current competitions\">");
-            for (CompetitionSummaryView competition : activeCompetitions) {
-                out.println(renderCompetitionOption(competition, selectedCompetitionId));
-            }
-            out.println("              </optgroup>");
-        }
-        if (pastCompetitions != null && !pastCompetitions.isEmpty()) {
-            out.println("              <optgroup label=\"Past competitions\">");
-            for (CompetitionSummaryView competition : pastCompetitions) {
-                out.println(renderCompetitionOption(competition, selectedCompetitionId));
-            }
-            out.println("              </optgroup>");
-        }
-        out.println("            </select>");
-        out.println("          </div>");
-        out.println("          <div class=\"col-md-3 d-grid\">");
-        out.println("            <button class=\"btn btn-outline-primary\" type=\"submit\">Open</button>");
-        out.println("          </div>");
-        out.println("        </form>");
-        out.println("      </div>");
-        out.println("    </div>");
-    }
-
-    private List<CompetitionSummaryView> competitions(HttpServletRequest request, String attributeName) {
-        Object competitionsAttr = request.getAttribute(attributeName);
-        if (competitionsAttr instanceof List<?> list) {
-            @SuppressWarnings("unchecked")
-            List<CompetitionSummaryView> cast = (List<CompetitionSummaryView>) list;
-            return cast;
-        }
-        return List.of();
-    }
-
-    private String renderCompetitionOption(CompetitionSummaryView competition, Long selectedCompetitionId) {
-        boolean selected = selectedCompetitionId != null && selectedCompetitionId == competition.getId();
-        return "              <option value=\"" + competition.getId() + "\"" + (selected ? " selected" : "") + ">" + WildflyUtils.escape(competition.getName()) + "</option>";
     }
 }

--- a/src/main/java/com/frankies/bootcamp/servlet/Auth0CallbackServlet.java
+++ b/src/main/java/com/frankies/bootcamp/servlet/Auth0CallbackServlet.java
@@ -38,6 +38,7 @@ public class Auth0CallbackServlet extends HttpServlet {
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
         HttpSession session = req.getSession(true);
+        String pendingInvitationToken = (String) session.getAttribute(AuthSessionService.PENDING_INVITATION_TOKEN_SESSION_KEY);
         String expectedState = (String) session.getAttribute("auth0State");
         String state = req.getParameter("state");
         String code = req.getParameter("code");
@@ -60,8 +61,16 @@ public class Auth0CallbackServlet extends HttpServlet {
             BootcampAthlete athlete = authService.loadAthleteForUser(user);
             req.changeSessionId();
             authSessionService.storeAuthenticatedUser(req, user, athlete);
-            resp.sendRedirect(req.getContextPath() + "/app/");
+            if (pendingInvitationToken != null && !pendingInvitationToken.isBlank()) {
+                authSessionService.setPendingInvitationToken(req, pendingInvitationToken);
+                log.debugf("Auth0 callback preserved pending invitation token for user=%s token=%s", user.getEmail(), pendingInvitationToken);
+                resp.sendRedirect(req.getContextPath() + "/invite?token=" + pendingInvitationToken);
+            } else {
+                log.debugf("Auth0 callback no pending invitation token for user=%s", user.getEmail());
+                resp.sendRedirect(req.getContextPath() + "/app/");
+            }
         } catch (IllegalArgumentException | SQLException e) {
+            log.error("Auth0 callback failed", e);
             authSessionService.clear(req);
             resp.sendRedirect(req.getContextPath() + "/");
         }

--- a/src/main/java/com/frankies/bootcamp/servlet/BootcampServlet.java
+++ b/src/main/java/com/frankies/bootcamp/servlet/BootcampServlet.java
@@ -2,6 +2,7 @@ package com.frankies.bootcamp.servlet;
 
 import com.frankies.bootcamp.model.BootcampAthlete;
 import com.frankies.bootcamp.model.AuthenticatedUser;
+import com.frankies.bootcamp.model.CompetitionSummaryView;
 import com.frankies.bootcamp.model.OnboardingState;
 import com.frankies.bootcamp.model.OnboardingStatus;
 import com.frankies.bootcamp.model.CompetitionInvitationView;
@@ -20,6 +21,8 @@ import org.jboss.logging.Logger;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.Set;
 
 public class BootcampServlet extends HttpServlet {
     private static final String SITE_HIT_LOGGED_SESSION_KEY = "siteHitLogged";
@@ -57,6 +60,7 @@ public class BootcampServlet extends HttpServlet {
         try {
             athlete = authService.loadAthleteForUser(authenticatedUser);
             req.setAttribute("competitionSetupAllowed", competitionAccessService.canAccessCompetitionSetup(authenticatedUser));
+            session.setAttribute("competitionSetupAllowed", competitionAccessService.canAccessCompetitionSetup(authenticatedUser));
             if (session.getAttribute(SITE_HIT_LOGGED_SESSION_KEY) == null) {
                 log.info("Site hit by " + authenticatedUser.getEmail());
                 session.setAttribute(SITE_HIT_LOGGED_SESSION_KEY, Boolean.TRUE);
@@ -65,6 +69,17 @@ public class BootcampServlet extends HttpServlet {
             OnboardingStatus onboardingStatus = onboardingStateService.resolve(authenticatedUser, athlete);
             applyOnboardingAttributes(req, session, authenticatedUser, athlete, onboardingStatus);
             applyInvitationAttributes(req, authenticatedUser, athlete);
+
+            if (isCompetitionManagementPath(req.getContextPath(), req.getRequestURI())) {
+                if (athlete != null) {
+                    log.debug("Competition management page bypassed onboarding gate for athlete: " + authenticatedUser.getEmail());
+                }
+                req.setAttribute("athlete", athlete);
+                req.setAttribute("athleteName", session.getAttribute("athleteName"));
+                req.setAttribute("athleteEmail", session.getAttribute("athleteEmail"));
+                super.service(req, resp);
+                return;
+            }
 
             if (onboardingStatus.getState() == OnboardingState.STRAVA_PENDING) {
                 log.debug("Strava link required: " + authenticatedUser.getEmail());
@@ -169,7 +184,7 @@ public class BootcampServlet extends HttpServlet {
                                            HttpSession session,
                                            AuthenticatedUser authenticatedUser,
                                            BootcampAthlete athlete,
-                                           OnboardingStatus onboardingStatus) {
+                                           OnboardingStatus onboardingStatus) throws SQLException {
         req.setAttribute("onboardingStatus", onboardingStatus);
         req.setAttribute("onboardingState", onboardingStatus.getState());
 
@@ -183,7 +198,25 @@ public class BootcampServlet extends HttpServlet {
         }
         req.setAttribute("activeCompetitions", onboardingStatus.getActiveCompetitions());
         req.setAttribute("pastCompetitions", onboardingStatus.getPastCompetitions());
+        req.setAttribute("activeCompetitionAdminIds", loadAdminCompetitionIds(athlete, onboardingStatus));
         req.setAttribute("selectedCompetitionId", selectedCompetitionId);
+        session.setAttribute("activeCompetitions", onboardingStatus.getActiveCompetitions());
+        session.setAttribute("pastCompetitions", onboardingStatus.getPastCompetitions());
+        session.setAttribute("activeCompetitionAdminIds", loadAdminCompetitionIds(athlete, onboardingStatus));
+        session.setAttribute("selectedCompetitionId", selectedCompetitionId);
+    }
+
+    private Set<Long> loadAdminCompetitionIds(BootcampAthlete athlete, OnboardingStatus onboardingStatus) throws SQLException {
+        Set<Long> adminCompetitionIds = new HashSet<>();
+        if (athlete == null || athlete.getId() == null || athlete.getId().isBlank() || onboardingStatus == null) {
+            return adminCompetitionIds;
+        }
+        for (CompetitionSummaryView competition : onboardingStatus.getActiveCompetitions()) {
+            if (competitionInvitationService.isAdmin(competition.getId(), athlete.getId())) {
+                adminCompetitionIds.add(competition.getId());
+            }
+        }
+        return adminCompetitionIds;
     }
 
     private void applyInvitationAttributes(HttpServletRequest req, AuthenticatedUser authenticatedUser, BootcampAthlete athlete) {
@@ -214,6 +247,11 @@ public class BootcampServlet extends HttpServlet {
             return onboardingStatus.getActiveCompetitions().get(0).getId();
         }
         return null;
+    }
+
+    static boolean isCompetitionManagementPath(String contextPath, String requestUri) {
+        String path = requestUri.substring(contextPath.length());
+        return "/app/competitions".equals(path);
     }
 
     private void syncSelectedCompetition(HttpServletRequest req, BootcampAthlete athlete) {

--- a/src/main/java/com/frankies/bootcamp/servlet/BootcampServlet.java
+++ b/src/main/java/com/frankies/bootcamp/servlet/BootcampServlet.java
@@ -4,11 +4,14 @@ import com.frankies.bootcamp.model.BootcampAthlete;
 import com.frankies.bootcamp.model.AuthenticatedUser;
 import com.frankies.bootcamp.model.OnboardingState;
 import com.frankies.bootcamp.model.OnboardingStatus;
+import com.frankies.bootcamp.model.CompetitionInvitationView;
 import com.frankies.bootcamp.service.AuthService;
 import com.frankies.bootcamp.service.OnboardingStateService;
 import com.frankies.bootcamp.service.StravaService;
 import com.frankies.bootcamp.service.AuthSessionService;
 import com.frankies.bootcamp.service.DBService;
+import com.frankies.bootcamp.service.CompetitionAccessService;
+import com.frankies.bootcamp.service.CompetitionInvitationService;
 import jakarta.inject.Inject;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.*;
@@ -19,6 +22,8 @@ import java.io.PrintWriter;
 import java.sql.SQLException;
 
 public class BootcampServlet extends HttpServlet {
+    private static final String SITE_HIT_LOGGED_SESSION_KEY = "siteHitLogged";
+
     @Inject
     private AuthSessionService authSessionService;
     @Inject
@@ -29,6 +34,10 @@ public class BootcampServlet extends HttpServlet {
     private OnboardingStateService onboardingStateService;
     @Inject
     private StravaService stravaService;
+    @Inject
+    private CompetitionInvitationService competitionInvitationService;
+    @Inject
+    private CompetitionAccessService competitionAccessService;
 
     private static final Logger log = Logger.getLogger(BootcampServlet.class);
 
@@ -47,44 +56,61 @@ public class BootcampServlet extends HttpServlet {
 
         try {
             athlete = authService.loadAthleteForUser(authenticatedUser);
+            req.setAttribute("competitionSetupAllowed", competitionAccessService.canAccessCompetitionSetup(authenticatedUser));
+            if (session.getAttribute(SITE_HIT_LOGGED_SESSION_KEY) == null) {
+                log.info("Site hit by " + authenticatedUser.getEmail());
+                session.setAttribute(SITE_HIT_LOGGED_SESSION_KEY, Boolean.TRUE);
+            }
             syncSelectedCompetition(req, athlete);
             OnboardingStatus onboardingStatus = onboardingStateService.resolve(authenticatedUser, athlete);
             applyOnboardingAttributes(req, session, authenticatedUser, athlete, onboardingStatus);
+            applyInvitationAttributes(req, authenticatedUser, athlete);
 
             if (onboardingStatus.getState() == OnboardingState.STRAVA_PENDING) {
-                log.info("Strava link required: " + authenticatedUser.getEmail());
+                log.debug("Strava link required: " + authenticatedUser.getEmail());
                 forwardToStravaOnboarding(req, resp, authenticatedUser, onboardingStatus);
                 return;
             }
 
             if (onboardingStatus.getState() == OnboardingState.COMPETITION_PENDING) {
-                log.info("Competition onboarding required: " + authenticatedUser.getEmail());
+                log.debug("Competition onboarding required: " + authenticatedUser.getEmail());
                 req.getRequestDispatcher("/app/competition-onboarding.jsp").forward(req, resp);
                 return;
             }
 
             if (onboardingStatus.getState() == OnboardingState.COMPETITION_STARTS_SOON) {
-                log.info("Competition starts soon for athlete: " + authenticatedUser.getEmail());
+                log.debug("Competition starts soon for athlete: " + authenticatedUser.getEmail());
                 req.getRequestDispatcher("/app/competition-starts-soon.jsp").forward(req, resp);
                 return;
             }
 
             if (onboardingStatus.getState() == OnboardingState.COMPETITION_SELECTION_REQUIRED
                     && authSessionService.getSelectedCompetitionId(req) == null) {
-                log.info("Competition selection required for athlete: " + authenticatedUser.getEmail());
+                log.debug("Competition selection required for athlete: " + authenticatedUser.getEmail());
                 req.getRequestDispatcher("/app/competition-selection.jsp").forward(req, resp);
                 return;
             }
 
             if (onboardingStatus.getState() == OnboardingState.COMPETITION_HISTORY_ONLY
                     && authSessionService.getSelectedCompetitionId(req) == null) {
-                log.info("Only past competitions available for athlete: " + authenticatedUser.getEmail());
+                log.debug("Only past competitions available for athlete: " + authenticatedUser.getEmail());
                 req.getRequestDispatcher("/app/competition-history-only.jsp").forward(req, resp);
                 return;
             }
 
+            String pendingInviteToken = authSessionService.getPendingInvitationToken(req);
+            if (pendingInviteToken != null && !isInvitationPath(req)) {
+                CompetitionInvitationView invitation = competitionInvitationService.resolveInvitationToken(pendingInviteToken);
+                if (invitation != null && invitation.isPending()) {
+                    req.setAttribute("pendingInvitation", invitation);
+                    req.getRequestDispatcher("/app/invitations").forward(req, resp);
+                    return;
+                }
+                authSessionService.clearPendingInvitationToken(req);
+            }
+
             if (athlete != null) {
-                log.info("Athlete authorised: " + buildDisplayName(athlete, authenticatedUser.getEmail()));
+                log.debug("Athlete authorised: " + buildDisplayName(athlete, authenticatedUser.getEmail()));
             }
         } catch (SQLException e) {
             log.error("Error resolving onboarding state", e);
@@ -160,6 +186,26 @@ public class BootcampServlet extends HttpServlet {
         req.setAttribute("selectedCompetitionId", selectedCompetitionId);
     }
 
+    private void applyInvitationAttributes(HttpServletRequest req, AuthenticatedUser authenticatedUser, BootcampAthlete athlete) {
+        try {
+            req.setAttribute("pendingCompetitionInvitations", competitionInvitationService.listPendingForUser(authenticatedUser, athlete));
+            Long selectedCompetitionId = authSessionService.getSelectedCompetitionId(req);
+            if (selectedCompetitionId != null && athlete != null && athlete.getId() != null && !athlete.getId().isBlank()) {
+                req.setAttribute("selectedCompetitionAdmin", competitionInvitationService.isAdmin(selectedCompetitionId, athlete.getId()));
+            } else {
+                req.setAttribute("selectedCompetitionAdmin", Boolean.FALSE);
+            }
+        } catch (SQLException e) {
+            log.error("Unable to load competition invitation attributes", e);
+            throw new RuntimeException("Unable to load competition invitations", e);
+        }
+    }
+
+    private boolean isInvitationPath(HttpServletRequest req) {
+        String path = req.getRequestURI().substring(req.getContextPath().length());
+        return "/app/invitations".equals(path) || "/app/invitations/respond".equals(path) || "/app/competition-invitations".equals(path);
+    }
+
     static Long defaultSelectedCompetitionId(Long storedCompetitionId, OnboardingStatus onboardingStatus) {
         if (storedCompetitionId != null || onboardingStatus == null) {
             return storedCompetitionId;
@@ -182,6 +228,7 @@ public class BootcampServlet extends HttpServlet {
             }
             req.setAttribute("selectedCompetitionId", selectedCompetitionId);
         } catch (SQLException e) {
+            log.errorf(e, "Unable to validate selected competition athleteId=%s competitionId=%s", athlete.getId(), selectedCompetitionId);
             throw new RuntimeException("Unable to validate selected competition", e);
         }
     }

--- a/src/main/java/com/frankies/bootcamp/servlet/CompetitionInvitationAdminServlet.java
+++ b/src/main/java/com/frankies/bootcamp/servlet/CompetitionInvitationAdminServlet.java
@@ -8,6 +8,7 @@ import com.frankies.bootcamp.model.CompetitionInvitationView;
 import com.frankies.bootcamp.service.AuthService;
 import com.frankies.bootcamp.service.AuthSessionService;
 import com.frankies.bootcamp.service.CompetitionInvitationService;
+import com.frankies.bootcamp.util.EmailDisplayUtil;
 import jakarta.inject.Inject;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
@@ -62,6 +63,7 @@ public class CompetitionInvitationAdminServlet extends BootcampServlet {
                         competitionId,
                         athlete.getUserId(),
                         req.getParameter("emails"),
+                        req.getParameter("message"),
                         req
                 );
                 feedback = result.createdInvites().isEmpty()
@@ -78,9 +80,12 @@ public class CompetitionInvitationAdminServlet extends BootcampServlet {
                         athlete.getUserId(),
                         invitedUserId,
                         invitedEmail,
+                        req.getParameter("message"),
                         req
                 );
-                feedback = "Created invitation for " + created.invitedEmail();
+                feedback = created.invitedUserId() != null
+                        ? "Created invitation for selected user."
+                        : "Created invitation for " + EmailDisplayUtil.maskEmail(created.invitedEmail());
             } else {
                 throw new IllegalArgumentException("Unsupported invite action.");
             }

--- a/src/main/java/com/frankies/bootcamp/servlet/CompetitionInvitationAdminServlet.java
+++ b/src/main/java/com/frankies/bootcamp/servlet/CompetitionInvitationAdminServlet.java
@@ -5,6 +5,7 @@ import com.frankies.bootcamp.model.BootcampAthlete;
 import com.frankies.bootcamp.model.CompetitionInvitationPageView;
 import com.frankies.bootcamp.model.CompetitionInviteCandidateView;
 import com.frankies.bootcamp.model.CompetitionInvitationView;
+import com.frankies.bootcamp.service.AiMessageService;
 import com.frankies.bootcamp.service.AuthService;
 import com.frankies.bootcamp.service.AuthSessionService;
 import com.frankies.bootcamp.service.CompetitionInvitationService;
@@ -30,9 +31,17 @@ public class CompetitionInvitationAdminServlet extends BootcampServlet {
     @Inject
     private AuthService authService;
 
+    @Inject
+    private AiMessageService aiMessageService;
+
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
         try {
+            String action = req.getParameter("action");
+            if ("rewriteMessage".equals(action)) {
+                handleRewriteMessage(req, resp);
+                return;
+            }
             long competitionId = resolveCompetitionId(req);
             BootcampAthlete athlete = requireAdminAthlete(req, competitionId);
             String query = req.getParameter("q");
@@ -47,6 +56,16 @@ public class CompetitionInvitationAdminServlet extends BootcampServlet {
         } catch (SQLException e) {
             throw new IOException("Unable to load competition invitations", e);
         }
+    }
+
+    private void handleRewriteMessage(HttpServletRequest req, HttpServletResponse resp) throws IOException, SQLException {
+        long competitionId = resolveCompetitionId(req);
+        requireAdminAthlete(req, competitionId);
+        CompetitionInvitationPageView view = competitionInvitationService.loadAdminPage(competitionId, null);
+        String currentMessage = req.getParameter("message");
+        String rewritten = aiMessageService.rewriteCompetitionInviteMessage(view.getCompetitionName(), currentMessage);
+        resp.setContentType("application/json; charset=UTF-8");
+        resp.getWriter().write("{\"message\":\"" + jsonEscape(rewritten) + "\",\"source\":\"" + ((currentMessage == null || currentMessage.isBlank()) ? "generated" : "refined") + "\"}");
     }
 
     @Override
@@ -118,13 +137,13 @@ public class CompetitionInvitationAdminServlet extends BootcampServlet {
     }
 
     private long resolveCompetitionId(HttpServletRequest req) throws SQLException {
-        Long selectedCompetitionId = authSessionService.getSelectedCompetitionId(req);
-        if (selectedCompetitionId != null) {
-            return selectedCompetitionId;
-        }
         String competitionId = req.getParameter("competitionId");
         if (competitionId != null && !competitionId.isBlank()) {
             return Long.parseLong(competitionId);
+        }
+        Long selectedCompetitionId = authSessionService.getSelectedCompetitionId(req);
+        if (selectedCompetitionId != null) {
+            return selectedCompetitionId;
         }
         throw new IllegalStateException("Competition selection required.");
     }
@@ -139,5 +158,12 @@ public class CompetitionInvitationAdminServlet extends BootcampServlet {
             throw new IllegalStateException("Admin access required");
         }
         return athlete;
+    }
+
+    private String jsonEscape(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.replace("\\", "\\\\").replace("\"", "\\\"").replace("\r", "\\r").replace("\n", "\\n");
     }
 }

--- a/src/main/java/com/frankies/bootcamp/servlet/CompetitionInvitationAdminServlet.java
+++ b/src/main/java/com/frankies/bootcamp/servlet/CompetitionInvitationAdminServlet.java
@@ -1,0 +1,138 @@
+package com.frankies.bootcamp.servlet;
+
+import com.frankies.bootcamp.model.AuthenticatedUser;
+import com.frankies.bootcamp.model.BootcampAthlete;
+import com.frankies.bootcamp.model.CompetitionInvitationPageView;
+import com.frankies.bootcamp.model.CompetitionInviteCandidateView;
+import com.frankies.bootcamp.model.CompetitionInvitationView;
+import com.frankies.bootcamp.service.AuthService;
+import com.frankies.bootcamp.service.AuthSessionService;
+import com.frankies.bootcamp.service.CompetitionInvitationService;
+import jakarta.inject.Inject;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.wildfly.security.credential.store.CredentialStoreException;
+
+import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
+import java.sql.SQLException;
+import java.util.List;
+
+@WebServlet(name = "competitionInvitationAdmin", value = "/app/competition-invitations")
+public class CompetitionInvitationAdminServlet extends BootcampServlet {
+    @Inject
+    private CompetitionInvitationService competitionInvitationService;
+    @Inject
+    private AuthSessionService authSessionService;
+    @Inject
+    private AuthService authService;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        try {
+            long competitionId = resolveCompetitionId(req);
+            BootcampAthlete athlete = requireAdminAthlete(req, competitionId);
+            String query = req.getParameter("q");
+            CompetitionInvitationPageView view = competitionInvitationService.loadAdminPage(competitionId, query);
+            req.setAttribute("adminAthlete", athlete);
+            req.setAttribute("invitationAdminView", view);
+            req.getRequestDispatcher("/app/competition-invitations.jsp").forward(req, resp);
+        } catch (IllegalStateException e) {
+            resp.sendRedirect(req.getContextPath() + "/app/");
+        } catch (ServletException e) {
+            throw new IOException("Unable to render competition invitations", e);
+        } catch (SQLException e) {
+            throw new IOException("Unable to load competition invitations", e);
+        }
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        try {
+            long competitionId = resolveCompetitionId(req);
+            BootcampAthlete athlete = requireAdminAthlete(req, competitionId);
+            String action = req.getParameter("action");
+            String feedback = null;
+            String error = null;
+
+            if ("bulkInvite".equals(action)) {
+                CompetitionInvitationService.InviteSubmissionResult result = competitionInvitationService.inviteByEmails(
+                        competitionId,
+                        athlete.getUserId(),
+                        req.getParameter("emails"),
+                        req
+                );
+                feedback = result.createdInvites().isEmpty()
+                        ? "No invitations were created."
+                        : "Created " + result.createdInvites().size() + " invitation(s).";
+                if (!result.errors().isEmpty()) {
+                    error = String.join("; ", result.errors());
+                }
+            } else if ("inviteCandidate".equals(action)) {
+                String invitedUserId = req.getParameter("invitedUserId");
+                String invitedEmail = req.getParameter("invitedEmail");
+                CompetitionInvitationService.InviteRecord created = competitionInvitationService.inviteExistingUser(
+                        competitionId,
+                        athlete.getUserId(),
+                        invitedUserId,
+                        invitedEmail,
+                        req
+                );
+                feedback = "Created invitation for " + created.invitedEmail();
+            } else {
+                throw new IllegalArgumentException("Unsupported invite action.");
+            }
+
+            CompetitionInvitationPageView view = competitionInvitationService.loadAdminPage(competitionId, req.getParameter("q"));
+            req.setAttribute("adminAthlete", athlete);
+            req.setAttribute("invitationAdminView", view);
+            req.setAttribute("invitationAdminFeedback", feedback);
+            req.setAttribute("invitationAdminError", error);
+            req.getRequestDispatcher("/app/competition-invitations.jsp").forward(req, resp);
+        } catch (IllegalStateException e) {
+            resp.sendRedirect(req.getContextPath() + "/app/");
+        } catch (IllegalArgumentException e) {
+            try {
+                long competitionId = resolveCompetitionId(req);
+                BootcampAthlete athlete = requireAdminAthlete(req, competitionId);
+                CompetitionInvitationPageView view = competitionInvitationService.loadAdminPage(competitionId, req.getParameter("q"));
+                req.setAttribute("adminAthlete", athlete);
+                req.setAttribute("invitationAdminView", view);
+                req.setAttribute("invitationAdminError", e.getMessage());
+                req.getRequestDispatcher("/app/competition-invitations.jsp").forward(req, resp);
+            } catch (SQLException | ServletException ex) {
+                throw new IOException("Unable to render competition invitations after validation error", ex);
+            }
+        } catch (ServletException e) {
+            throw new IOException("Unable to render competition invitations", e);
+        } catch (SQLException e) {
+            throw new IOException("Unable to load competition invitations", e);
+        }
+    }
+
+    private long resolveCompetitionId(HttpServletRequest req) throws SQLException {
+        Long selectedCompetitionId = authSessionService.getSelectedCompetitionId(req);
+        if (selectedCompetitionId != null) {
+            return selectedCompetitionId;
+        }
+        String competitionId = req.getParameter("competitionId");
+        if (competitionId != null && !competitionId.isBlank()) {
+            return Long.parseLong(competitionId);
+        }
+        throw new IllegalStateException("Competition selection required.");
+    }
+
+    private BootcampAthlete requireAdminAthlete(HttpServletRequest req, long competitionId) throws SQLException {
+        AuthenticatedUser user = authSessionService.getAuthenticatedUser(req);
+        if (user == null) {
+            throw new IllegalStateException("Login required");
+        }
+        BootcampAthlete athlete = authService.loadAthleteForUser(user);
+        if (athlete == null || athlete.getId() == null || athlete.getId().isBlank() || !competitionInvitationService.isAdmin(competitionId, athlete.getId())) {
+            throw new IllegalStateException("Admin access required");
+        }
+        return athlete;
+    }
+}

--- a/src/main/java/com/frankies/bootcamp/servlet/CompetitionInvitationResponseServlet.java
+++ b/src/main/java/com/frankies/bootcamp/servlet/CompetitionInvitationResponseServlet.java
@@ -1,0 +1,81 @@
+package com.frankies.bootcamp.servlet;
+
+import com.frankies.bootcamp.model.AuthenticatedUser;
+import com.frankies.bootcamp.model.BootcampAthlete;
+import com.frankies.bootcamp.model.CompetitionInvitationView;
+import com.frankies.bootcamp.service.ActivityProcessFacade;
+import com.frankies.bootcamp.service.AuthService;
+import com.frankies.bootcamp.service.AuthSessionService;
+import com.frankies.bootcamp.service.CompetitionInvitationService;
+import jakarta.inject.Inject;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.jboss.logging.Logger;
+
+import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
+import java.sql.SQLException;
+
+import org.wildfly.security.credential.store.CredentialStoreException;
+
+@WebServlet(name = "competitionInvitationResponse", value = "/app/invitations/respond")
+public class CompetitionInvitationResponseServlet extends jakarta.servlet.http.HttpServlet {
+    private static final Logger log = Logger.getLogger(CompetitionInvitationResponseServlet.class);
+
+    @Inject
+    private CompetitionInvitationService competitionInvitationService;
+    @Inject
+    private AuthSessionService authSessionService;
+    @Inject
+    private AuthService authService;
+    @Inject
+    private ActivityProcessFacade activityProcessFacade;
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        AuthenticatedUser user = authSessionService.getAuthenticatedUser(req);
+        if (user == null) {
+            resp.sendRedirect(req.getContextPath() + "/login");
+            return;
+        }
+
+        try {
+            BootcampAthlete athlete = authService.loadAthleteForUser(user);
+            String action = req.getParameter("action");
+            long invitationId = Long.parseLong(req.getParameter("invitationId"));
+            log.debugf("Invitation response action=%s invitationId=%d user=%s", action, invitationId, user.getEmail());
+            if ("decline".equals(action)) {
+                competitionInvitationService.declineInvitation(invitationId);
+                authSessionService.clearPendingInvitationToken(req);
+                resp.sendRedirect(req.getContextPath() + "/app/invitations?status=declined");
+                return;
+            }
+
+            String startingGoalValue = req.getParameter("startingGoal");
+            double startingGoal = startingGoalValue == null || startingGoalValue.isBlank()
+                    ? (athlete != null && athlete.getGoal() != null ? athlete.getGoal() : 0.0)
+                    : Double.parseDouble(startingGoalValue);
+
+            CompetitionInvitationView invitation = competitionInvitationService.resolveInvitationToken(req.getParameter("token"));
+            if (invitation == null) {
+                resp.sendRedirect(req.getContextPath() + "/app/invitations?error=invalid");
+                return;
+            }
+
+            CompetitionInvitationService.InvitationDecisionResult result = competitionInvitationService.acceptInvitation(invitationId, athlete, startingGoal, user.getUserId());
+            if (result.success()) {
+                log.debugf("Invitation accepted invitationId=%d competitionId=%d athleteId=%s", invitationId, invitation.getCompetitionId(), athlete == null ? null : athlete.getId());
+                authSessionService.setSelectedCompetitionId(req, invitation.getCompetitionId());
+                activityProcessFacade.prepareAthleteSummaryForCompetition(athlete, invitation.getCompetitionId());
+                authSessionService.clearPendingInvitationToken(req);
+                resp.sendRedirect(req.getContextPath() + "/app/?invite=accepted");
+                return;
+            }
+            resp.sendRedirect(req.getContextPath() + "/app/invitations?error=" + java.net.URLEncoder.encode(result.message(), java.nio.charset.StandardCharsets.UTF_8));
+        } catch (SQLException | NumberFormatException | CredentialStoreException | NoSuchAlgorithmException e) {
+            throw new IOException("Unable to process invitation response", e);
+        }
+    }
+}

--- a/src/main/java/com/frankies/bootcamp/servlet/CompetitionInvitationsServlet.java
+++ b/src/main/java/com/frankies/bootcamp/servlet/CompetitionInvitationsServlet.java
@@ -1,0 +1,45 @@
+package com.frankies.bootcamp.servlet;
+
+import com.frankies.bootcamp.model.AuthenticatedUser;
+import com.frankies.bootcamp.model.BootcampAthlete;
+import com.frankies.bootcamp.model.CompetitionInvitationView;
+import com.frankies.bootcamp.service.AuthService;
+import com.frankies.bootcamp.service.AuthSessionService;
+import com.frankies.bootcamp.service.CompetitionInvitationService;
+import jakarta.inject.Inject;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.wildfly.security.credential.store.CredentialStoreException;
+
+import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
+import java.sql.SQLException;
+import java.util.List;
+
+@WebServlet(name = "competitionInvitations", value = "/app/invitations")
+public class CompetitionInvitationsServlet extends BootcampServlet {
+    @Inject
+    private CompetitionInvitationService competitionInvitationService;
+    @Inject
+    private AuthSessionService authSessionService;
+    @Inject
+    private AuthService authService;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        try {
+            AuthenticatedUser user = authSessionService.getAuthenticatedUser(req);
+            BootcampAthlete athlete = authService.loadAthleteForUser(user);
+            List<CompetitionInvitationView> invitations = competitionInvitationService.listPendingForUser(user, athlete);
+            req.setAttribute("pendingCompetitionInvitations", invitations);
+            req.setAttribute("pendingInvitation", req.getAttribute("pendingInvitation"));
+            req.getRequestDispatcher("/app/invitations.jsp").forward(req, resp);
+        } catch (ServletException e) {
+            throw new IOException("Unable to render invitations", e);
+        } catch (SQLException e) {
+            throw new IOException("Unable to load invitations", e);
+        }
+    }
+}

--- a/src/main/java/com/frankies/bootcamp/servlet/CompetitionSetupServlet.java
+++ b/src/main/java/com/frankies/bootcamp/servlet/CompetitionSetupServlet.java
@@ -2,9 +2,11 @@ package com.frankies.bootcamp.servlet;
 
 import com.frankies.bootcamp.model.AuthenticatedUser;
 import com.frankies.bootcamp.model.BootcampAthlete;
+import com.frankies.bootcamp.model.CompetitionInvitationView;
 import com.frankies.bootcamp.service.AuthService;
 import com.frankies.bootcamp.service.AuthSessionService;
 import com.frankies.bootcamp.service.CompetitionAccessService;
+import com.frankies.bootcamp.service.CompetitionInvitationService;
 import com.frankies.bootcamp.service.CompetitionSetupService;
 import jakarta.inject.Inject;
 import jakarta.servlet.ServletException;
@@ -18,6 +20,7 @@ import org.wildfly.security.credential.store.CredentialStoreException;
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
 import java.sql.SQLException;
+import java.util.List;
 
 @WebServlet(name = "competitionSetup", value = "/app/competition-setup")
 public class CompetitionSetupServlet extends HttpServlet {
@@ -35,6 +38,9 @@ public class CompetitionSetupServlet extends HttpServlet {
     @Inject
     private CompetitionAccessService competitionAccessService;
 
+    @Inject
+    private CompetitionInvitationService competitionInvitationService;
+
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         try {
@@ -44,6 +50,7 @@ public class CompetitionSetupServlet extends HttpServlet {
                 return;
             }
             req.setAttribute("competitionSetupView", competitionSetupService.loadView(athlete));
+            applyInvitationAttributes(req, athlete);
             req.getRequestDispatcher("/app/competition-setup.jsp").forward(req, resp);
         } catch (IllegalStateException e) {
             log.error("Competition setup GET rejected", e);
@@ -66,7 +73,7 @@ public class CompetitionSetupServlet extends HttpServlet {
             }
 
             if ("create".equals(action)) {
-                competitionSetupService.createCompetitionAndJoin(
+                long competitionId = competitionSetupService.createCompetitionAndJoin(
                         athlete,
                         req.getParameter("competitionName"),
                         req.getParameter("timezone"),
@@ -74,6 +81,9 @@ public class CompetitionSetupServlet extends HttpServlet {
                         req.getParameter("endDate"),
                         req.getParameter("startingGoal")
                 );
+                authSessionService.setSelectedCompetitionId(req, competitionId);
+                resp.sendRedirect(req.getContextPath() + "/app/competition-invitations?competitionId=" + competitionId);
+                return;
             } else if ("join".equals(action)) {
                 competitionSetupService.joinCompetition(
                         athlete,
@@ -83,7 +93,6 @@ public class CompetitionSetupServlet extends HttpServlet {
             } else {
                 throw new IllegalArgumentException("Unsupported competition setup action.");
             }
-
             resp.sendRedirect(req.getContextPath() + "/app");
         } catch (IllegalArgumentException e) {
             log.error("Competition setup validation failed", e);
@@ -108,8 +117,15 @@ public class CompetitionSetupServlet extends HttpServlet {
     private void reloadWithError(HttpServletRequest req, HttpServletResponse resp, String error) throws ServletException, IOException, SQLException {
         BootcampAthlete athlete = requireLinkedAthlete(req);
         req.setAttribute("competitionSetupView", competitionSetupService.loadView(athlete));
+        applyInvitationAttributes(req, athlete);
         req.setAttribute("competitionSetupError", error);
         req.getRequestDispatcher("/app/competition-setup.jsp").forward(req, resp);
+    }
+
+    private void applyInvitationAttributes(HttpServletRequest req, BootcampAthlete athlete) throws SQLException {
+        AuthenticatedUser authenticatedUser = authSessionService.getAuthenticatedUser(req);
+        List<CompetitionInvitationView> invitations = competitionInvitationService.listPendingForUser(authenticatedUser, athlete);
+        req.setAttribute("pendingCompetitionInvitations", invitations);
     }
 
     private BootcampAthlete requireLinkedAthlete(HttpServletRequest req) throws SQLException {

--- a/src/main/java/com/frankies/bootcamp/servlet/CompetitionSetupServlet.java
+++ b/src/main/java/com/frankies/bootcamp/servlet/CompetitionSetupServlet.java
@@ -4,6 +4,7 @@ import com.frankies.bootcamp.model.AuthenticatedUser;
 import com.frankies.bootcamp.model.BootcampAthlete;
 import com.frankies.bootcamp.service.AuthService;
 import com.frankies.bootcamp.service.AuthSessionService;
+import com.frankies.bootcamp.service.CompetitionAccessService;
 import com.frankies.bootcamp.service.CompetitionSetupService;
 import jakarta.inject.Inject;
 import jakarta.servlet.ServletException;
@@ -11,6 +12,7 @@ import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.jboss.logging.Logger;
 import org.wildfly.security.credential.store.CredentialStoreException;
 
 import java.io.IOException;
@@ -19,6 +21,8 @@ import java.sql.SQLException;
 
 @WebServlet(name = "competitionSetup", value = "/app/competition-setup")
 public class CompetitionSetupServlet extends HttpServlet {
+    private static final Logger log = Logger.getLogger(CompetitionSetupServlet.class);
+
     @Inject
     private AuthSessionService authSessionService;
 
@@ -28,15 +32,24 @@ public class CompetitionSetupServlet extends HttpServlet {
     @Inject
     private CompetitionSetupService competitionSetupService;
 
+    @Inject
+    private CompetitionAccessService competitionAccessService;
+
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         try {
             BootcampAthlete athlete = requireLinkedAthlete(req);
+            if (!competitionAccessService.canAccessCompetitionSetup(authSessionService.getAuthenticatedUser(req))) {
+                resp.sendRedirect(req.getContextPath() + "/app");
+                return;
+            }
             req.setAttribute("competitionSetupView", competitionSetupService.loadView(athlete));
             req.getRequestDispatcher("/app/competition-setup.jsp").forward(req, resp);
         } catch (IllegalStateException e) {
+            log.error("Competition setup GET rejected", e);
             resp.sendRedirect(req.getContextPath() + "/app");
         } catch (SQLException e) {
+            log.error("Unable to load competition setup view", e);
             throw new ServletException("Unable to load competition setup view", e);
         }
     }
@@ -47,6 +60,10 @@ public class CompetitionSetupServlet extends HttpServlet {
 
         try {
             BootcampAthlete athlete = requireLinkedAthlete(req);
+            if (!competitionAccessService.canAccessCompetitionSetup(authSessionService.getAuthenticatedUser(req))) {
+                resp.sendRedirect(req.getContextPath() + "/app");
+                return;
+            }
 
             if ("create".equals(action)) {
                 competitionSetupService.createCompetitionAndJoin(
@@ -69,16 +86,21 @@ public class CompetitionSetupServlet extends HttpServlet {
 
             resp.sendRedirect(req.getContextPath() + "/app");
         } catch (IllegalArgumentException e) {
+            log.error("Competition setup validation failed", e);
             try {
                 reloadWithError(req, resp, e.getMessage());
             } catch (SQLException sqlException) {
+                log.error("Unable to reload competition setup after validation error", sqlException);
                 throw new ServletException("Unable to reload competition setup after validation error", sqlException);
             }
         } catch (IllegalStateException e) {
+            log.error("Competition setup blocked", e);
             resp.sendRedirect(req.getContextPath() + "/app");
         } catch (SQLException e) {
+            log.error("Unable to save competition setup", e);
             throw new ServletException("Unable to save competition setup", e);
         } catch (CredentialStoreException | NoSuchAlgorithmException e) {
+            log.error("Unable to refresh athlete competition data after setup", e);
             throw new ServletException("Unable to refresh athlete competition data after setup", e);
         }
     }

--- a/src/main/java/com/frankies/bootcamp/servlet/HonourRollServlet.java
+++ b/src/main/java/com/frankies/bootcamp/servlet/HonourRollServlet.java
@@ -37,15 +37,6 @@ public class HonourRollServlet extends BootcampServlet {
         Map<String, String> athleteIdsByName = athleteIdsByName(selectedCompetitionId);
         int numberOfWeeksSinceStart = activityProcessFacade.getNumberOfWeeksSinceStart();
 
-        out.println("<!DOCTYPE html>");
-        out.println("<html lang=\"en\">");
-        out.println("<head>");
-        out.println("  <meta charset=\"UTF-8\">");
-        out.println("  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">");
-        out.println("  <title>Frankies Bootcamp - Honour Roll</title>");
-        out.println("</head>");
-        out.println("<body>");
-
         out.println("<div class='container'>");
         out.println("<h2 class='history-heading'>");
         out.println("<i class='bi bi-award-fill'></i> Bootcamp Honour Roll: Finishers & Front-Runners");
@@ -80,9 +71,7 @@ public class HonourRollServlet extends BootcampServlet {
         out.println("  </tbody>");
         out.println("</table>");
         out.println("</div>");
-        out.println("  </div>");
-        out.println("</body>");
-        out.println("</html>");
+        out.println("</div>");
     }
 
     private Map<String, String> athleteIdsByName(Long selectedCompetitionId) {

--- a/src/main/java/com/frankies/bootcamp/servlet/InsightsServlet.java
+++ b/src/main/java/com/frankies/bootcamp/servlet/InsightsServlet.java
@@ -278,6 +278,15 @@ public class InsightsServlet extends BootcampServlet {
     }
 
     private void renderProfileContent(PrintWriter out, CompetitionInsights.AthleteProfileSummary profile, AthleteProfileBlurb blurb, String loggedInAthleteId, String profileSummaryAction, String profileSummaryGenerateUrl) {
+        out.println("<div class='d-flex align-items-center gap-3 mb-3'>");
+        if (profile.profileMedium() != null && !profile.profileMedium().isBlank()) {
+            out.println("<img src='" + escapeAttribute(profile.profileMedium()) + "' alt='' class='rounded-circle border' style='width:56px;height:56px;object-fit:cover;' onerror=\"this.style.display='none';this.nextElementSibling.classList.remove('d-none');\">");
+            out.println("<span class='rounded-circle border d-none d-inline-flex align-items-center justify-content-center' style='width:56px;height:56px;'><i class='bi bi-person'></i></span>");
+        } else {
+            out.println("<span class='rounded-circle border d-inline-flex align-items-center justify-content-center' style='width:56px;height:56px;'><i class='bi bi-person'></i></span>");
+        }
+        out.println("<div><div class='fw-semibold'>" + escape(profile.athleteName()) + "</div><div class='text-muted small'>Strava athlete</div></div>");
+        out.println("</div>");
         renderProfileBlurb(out, profile, blurb, loggedInAthleteId, profileSummaryAction, profileSummaryGenerateUrl);
         out.println("<div class='row g-3'>");
         metric(out, "Overall rank", "#" + profile.overallRank());

--- a/src/main/java/com/frankies/bootcamp/servlet/InsightsServlet.java
+++ b/src/main/java/com/frankies/bootcamp/servlet/InsightsServlet.java
@@ -20,7 +20,6 @@ import java.io.PrintWriter;
 import java.sql.SQLException;
 import java.text.DecimalFormat;
 import java.util.Comparator;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -39,52 +38,70 @@ public class InsightsServlet extends BootcampServlet {
 
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        response.setContentType("text/html");
         BootcampAthlete loggedInAthlete = (BootcampAthlete) request.getAttribute("athlete");
         Long selectedCompetitionId = (Long) request.getAttribute("selectedCompetitionId");
-        if (loggedInAthlete == null || selectedCompetitionId == null) {
+        if (loggedInAthlete == null) {
             response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        String fragment = trimToEmpty(request.getParameter("fragment"));
+        if ("profile".equals(fragment)) {
+            renderProfileFragment(request, response, loggedInAthlete, selectedCompetitionId);
+            return;
+        }
+
+        response.setContentType("text/html");
+        PrintWriter out = response.getWriter();
+        out.println("<div class='container'>");
+        out.println("<h2 class='history-heading'><i class='bi bi-lightbulb-fill'></i> Competition Insights</h2>");
+        if (selectedCompetitionId == null) {
+            out.println("<div class='alert alert-info'>Select a competition to view insights.</div>");
+            out.println("</div>");
             return;
         }
 
         List<PerformanceResponse> performances = activityProcessFacade.getPerformanceListForCompetition(selectedCompetitionId);
         boolean excludeLatestWeek = selectedCompetitionIsActive(request, selectedCompetitionId);
         CompetitionInsights insights = competitionInsightsService.buildInsights(performances, loggedInAthlete.getId(), excludeLatestWeek);
-        Map<String, AthleteProfileBlurb> profileBlurbs = profileBlurbs(insights);
 
-        PrintWriter out = response.getWriter();
-        out.println("<div class='container'>");
-        out.println("<h2 class='history-heading'><i class='bi bi-lightbulb-fill'></i> Competition Insights</h2>");
         out.println("<p class='history-subheading'>Trends, standings, and athlete highlights. Distances stay private. Active competitions use completed weeks only.</p>");
-        String profileSummaryAction = request.getContextPath() + "/app/AthleteProfileSummary";
-        String profileSummaryGenerateUrl = request.getContextPath() + "/app/AthleteProfileSummary";
-        renderProfile(out, insights, profileBlurbs, loggedInAthlete.getId(), profileSummaryAction, profileSummaryGenerateUrl);
         renderRankTrend(out, insights);
         renderWeeklyHistory(out, insights);
         renderSportStandings(out, insights);
-        renderProfileModal(out, insights, profileBlurbs, loggedInAthlete.getId(), profileSummaryAction, profileSummaryGenerateUrl);
         out.println("</div>");
     }
 
-    private void renderProfile(PrintWriter out, CompetitionInsights insights, Map<String, AthleteProfileBlurb> profileBlurbs, String loggedInAthleteId, String profileSummaryAction, String profileSummaryGenerateUrl) {
-        CompetitionInsights.AthleteProfileSummary profile = insights.selectedAthleteProfile();
-        if (profile == null) {
-            out.println("<div class='alert alert-info'>No insights are available yet.</div>");
+    private void renderProfileFragment(HttpServletRequest request, HttpServletResponse response, BootcampAthlete loggedInAthlete, Long selectedCompetitionId) throws IOException {
+        String athleteId = trimToEmpty(request.getParameter("athleteId"));
+        if (athleteId.isBlank()) {
+            athleteId = loggedInAthlete.getId();
+        }
+        if (athleteId == null || athleteId.isBlank()) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Athlete is required.");
             return;
         }
 
-        out.println("<section class='card mb-4'><div class='card-body'>");
-        out.println("<h3 class='h5'>" + escape(profile.athleteName()) + " profile</h3>");
-        renderProfileContent(out, profile, profileBlurbs.get(profile.athleteId()), loggedInAthleteId, profileSummaryAction, profileSummaryGenerateUrl);
-        out.println("<div class='mt-3'><label for='athleteProfileSelect' class='form-label fw-bold'>View another athlete</label>");
-        out.println("<select id='athleteProfileSelect' class='form-select' style='max-width: 24rem;'>");
-        out.println("<option value=''>Choose an athlete...</option>");
-        for (CompetitionInsights.AthleteProfileSummary athleteProfile : insights.athleteProfiles()) {
-            out.println("<option value='" + escapeAttribute(athleteProfile.athleteId()) + "' data-athlete-profile-name='" + escapeAttribute(athleteProfile.athleteName()) + "'>"
-                    + escape(athleteProfile.athleteName()) + "</option>");
+        List<PerformanceResponse> performances = activityProcessFacade.getPerformanceListForCompetition(selectedCompetitionId);
+        boolean excludeLatestWeek = selectedCompetitionIsActive(request, selectedCompetitionId);
+        CompetitionInsights insights = competitionInsightsService.buildInsights(performances, athleteId, excludeLatestWeek);
+        CompetitionInsights.AthleteProfileSummary profile = insights.selectedAthleteProfile();
+        if (profile == null) {
+            response.sendError(HttpServletResponse.SC_NOT_FOUND);
+            return;
         }
-        out.println("</select></div>");
-        out.println("</div></section>");
+
+        response.setContentType("text/html; charset=UTF-8");
+        PrintWriter out = response.getWriter();
+        AthleteProfileBlurb verifiedBlurb = null;
+        try {
+            verifiedBlurb = dbService.getVerifiedAthleteProfileBlurb(profile.athleteId());
+        } catch (SQLException e) {
+            log.warn("Could not load verified athlete profile blurb for " + profile.athleteId(), e);
+        }
+        String profileSummaryAction = request.getContextPath() + "/app/AthleteProfileSummary";
+        String profileSummaryGenerateUrl = request.getContextPath() + "/app/AthleteProfileSummary";
+        renderProfileContent(out, profile, verifiedBlurb, loggedInAthlete.getId(), profileSummaryAction, profileSummaryGenerateUrl);
     }
 
     private void renderRankTrend(PrintWriter out, CompetitionInsights insights) {
@@ -160,17 +177,92 @@ public class InsightsServlet extends BootcampServlet {
     private void renderWeeklyHistory(PrintWriter out, CompetitionInsights insights) {
         out.println("<section class='mb-4'>");
         out.println("<h3 class='h5'>Week-by-week leaderboard winners</h3>");
-        out.println("<div class='table-responsive'><table class='table table-sm table-striped align-middle'>");
-        out.println("<thead><tr><th>Week</th><th>Leader</th><th>Points</th><th>Top three</th></tr></thead><tbody>");
-        for (CompetitionInsights.WeeklyLeaderboard leaderboard : insights.weeklyLeaderboards()) {
-            if (leaderboard.entries().isEmpty()) {
-                continue;
-            }
-            CompetitionInsights.RankedAthleteMetric leader = leaderboard.entries().get(0);
-            out.println("<tr><td>Week " + leaderboard.weekNumber() + "</td><td>" + escape(leader.athleteName())
-                    + "</td><td>" + format(leader.sortValue()) + "</td><td>" + topThree(leaderboard) + "</td></tr>");
+        List<CompetitionInsights.WeeklyLeaderboard> leaderboards = insights.weeklyLeaderboards();
+        List<CompetitionInsights.WeeklyLeaderboard> visibleLeaderboards = leaderboards.stream()
+                .filter(leaderboard -> !leaderboard.entries().isEmpty())
+                .toList();
+        if (visibleLeaderboards.isEmpty()) {
+            out.println("<div class='alert alert-info'>No weekly history is available yet.</div>");
+            out.println("</section>");
+            return;
         }
-        out.println("</tbody></table></div></section>");
+
+        out.println("<div class='card shadow-sm border-0'>");
+        out.println("<div class='card-body'>");
+        out.println("<div class='d-flex flex-wrap gap-2 align-items-center justify-content-between mb-3'>");
+        out.println("<div class='btn-group' role='group' aria-label='Week navigation'>");
+        out.println("<button type='button' class='btn btn-outline-secondary' id='weekHistoryPrevBtn' aria-label='Previous week'><i class='bi bi-chevron-left'></i></button>");
+        out.println("<button type='button' class='btn btn-outline-secondary' id='weekHistoryNextBtn' aria-label='Next week'><i class='bi bi-chevron-right'></i></button>");
+        out.println("</div>");
+        out.println("<div class='flex-grow-1' style='min-width: 14rem; max-width: 24rem;'>");
+        out.println("<label class='form-label mb-1' for='weekHistoryWeekSelect'>Choose a week</label>");
+        out.println("<select class='form-select' id='weekHistoryWeekSelect'>");
+        for (int i = 0; i < visibleLeaderboards.size(); i++) {
+            CompetitionInsights.WeeklyLeaderboard leaderboard = visibleLeaderboards.get(i);
+            out.println("<option value='" + i + "'>Week " + leaderboard.weekNumber() + "</option>");
+        }
+        out.println("</select>");
+        out.println("</div>");
+        out.println("</div>");
+
+        out.println("<div class='border rounded p-3 bg-light' aria-live='polite'>");
+        out.println("<div class='d-flex justify-content-between align-items-start gap-3 flex-wrap mb-2'>");
+        out.println("<div>");
+        out.println("<div class='text-muted small'>Selected week</div>");
+        out.println("<div class='h4 mb-0' id='weekHistoryLabel'></div>");
+        out.println("</div>");
+        out.println("<div class='text-end'>");
+        out.println("<div class='text-muted small'>Leader</div>");
+        out.println("<div class='fw-semibold' id='weekHistoryLeader'></div>");
+        out.println("</div>");
+        out.println("</div>");
+        out.println("<div class='row g-3'>");
+        out.println("<div class='col-md-4'><div class='card h-100'><div class='card-body'><div class='text-muted small'>Points</div><div class='h5 mb-0' id='weekHistoryPoints'></div></div></div></div>");
+        out.println("<div class='col-md-8'><div class='card h-100'><div class='card-body'><div class='text-muted small'>Top three</div><div class='fw-semibold' id='weekHistoryTopThree'></div></div></div></div>");
+        out.println("</div>");
+        out.println("</div>");
+        out.println("</div>");
+        out.println("</div></section>");
+
+        out.println("<script>");
+        out.println("(function () {");
+        out.println("const weeks = [");
+        for (int i = 0; i < visibleLeaderboards.size(); i++) {
+            CompetitionInsights.WeeklyLeaderboard leaderboard = visibleLeaderboards.get(i);
+            CompetitionInsights.RankedAthleteMetric leader = leaderboard.entries().get(0);
+            out.println("{weekNumber:" + leaderboard.weekNumber()
+                    + ", leader:" + jsString(leader.athleteName())
+                    + ", points:" + jsString(format(leader.sortValue()))
+                    + ", topThree:" + jsString(topThree(leaderboard))
+                    + "}" + (i < visibleLeaderboards.size() - 1 ? "," : ""));
+        }
+        out.println("];");
+        out.println("const select = document.getElementById('weekHistoryWeekSelect');");
+        out.println("const prev = document.getElementById('weekHistoryPrevBtn');");
+        out.println("const next = document.getElementById('weekHistoryNextBtn');");
+        out.println("const label = document.getElementById('weekHistoryLabel');");
+        out.println("const leader = document.getElementById('weekHistoryLeader');");
+        out.println("const points = document.getElementById('weekHistoryPoints');");
+        out.println("const topThree = document.getElementById('weekHistoryTopThree');");
+        out.println("if (!select || !prev || !next || !label || !leader || !points || !topThree || !weeks.length) { return; }");
+        out.println("let index = 0;");
+        out.println("function renderWeek(nextIndex) {");
+        out.println("index = Math.max(0, Math.min(weeks.length - 1, nextIndex));");
+        out.println("const week = weeks[index];");
+        out.println("select.value = String(index);");
+        out.println("label.textContent = 'Week ' + week.weekNumber;");
+        out.println("leader.textContent = week.leader;");
+        out.println("points.textContent = week.points;");
+        out.println("topThree.textContent = week.topThree;");
+        out.println("prev.disabled = index === 0;");
+        out.println("next.disabled = index === weeks.length - 1;");
+        out.println("}");
+        out.println("select.addEventListener('change', function () { renderWeek(parseInt(select.value, 10)); });");
+        out.println("prev.addEventListener('click', function () { renderWeek(index - 1); });");
+        out.println("next.addEventListener('click', function () { renderWeek(index + 1); });");
+        out.println("renderWeek(0);");
+        out.println("})();");
+        out.println("</script>");
     }
 
     private void renderSportStandings(PrintWriter out, CompetitionInsights insights) {
@@ -189,94 +281,6 @@ public class InsightsServlet extends BootcampServlet {
         out.println("</div></section>");
     }
 
-    private void renderProfileModal(PrintWriter out, CompetitionInsights insights, Map<String, AthleteProfileBlurb> profileBlurbs, String loggedInAthleteId, String profileSummaryAction, String profileSummaryGenerateUrl) {
-        out.println("<div class='modal fade' id='athleteProfileModal' tabindex='-1' aria-labelledby='athleteProfileModalTitle' aria-hidden='true'>");
-        out.println("<div class='modal-dialog modal-lg modal-dialog-scrollable'><div class='modal-content'>");
-        out.println("<div class='modal-header'><h5 class='modal-title' id='athleteProfileModalTitle'>Athlete profile</h5>");
-        out.println("<button type='button' class='btn-close' data-bs-dismiss='modal' aria-label='Close'></button></div>");
-        out.println("<div class='modal-body'>");
-        for (CompetitionInsights.AthleteProfileSummary profile : insights.athleteProfiles()) {
-            out.println("<div class='athlete-profile-modal-body d-none' data-athlete-profile-body='" + escapeAttribute(profile.athleteId()) + "'>");
-            renderProfileContent(out, profile, profileBlurbs.get(profile.athleteId()), loggedInAthleteId, profileSummaryAction, profileSummaryGenerateUrl);
-            out.println("</div>");
-        }
-        out.println("</div></div></div></div>");
-        out.println("<script>");
-        out.println("(function(){");
-        out.println("var modalElement=document.getElementById('athleteProfileModal');");
-        out.println("if(!modalElement || modalElement.dataset.bound==='true') return;");
-        out.println("if(modalElement.parentElement!==document.body){document.body.appendChild(modalElement);}");
-        out.println("modalElement.dataset.bound='true';");
-        out.println("document.addEventListener('click',function(event){");
-        out.println("var trigger=event.target.closest('[data-athlete-profile-id]');");
-        out.println("if(!trigger) return;");
-        out.println("event.preventDefault();");
-        out.println("var athleteId=trigger.getAttribute('data-athlete-profile-id');");
-        out.println("var athleteName=trigger.getAttribute('data-athlete-profile-name') || 'Athlete profile';");
-        out.println("showAthleteProfile(athleteId, athleteName);");
-        out.println("});");
-        out.println("document.addEventListener('change',function(event){");
-        out.println("if(event.target.id!=='athleteProfileSelect' || !event.target.value) return;");
-        out.println("var option=event.target.options[event.target.selectedIndex];");
-        out.println("showAthleteProfile(event.target.value, option.getAttribute('data-athlete-profile-name') || option.textContent);");
-        out.println("event.target.value='';");
-        out.println("});");
-        out.println("function showAthleteProfile(athleteId, athleteName){");
-        out.println("modalElement.querySelectorAll('.athlete-profile-modal-body').forEach(function(body){body.classList.add('d-none');});");
-        out.println("var body=null;");
-        out.println("modalElement.querySelectorAll('.athlete-profile-modal-body').forEach(function(candidate){if(candidate.getAttribute('data-athlete-profile-body')===athleteId){body=candidate;}});");
-        out.println("if(!body) return;");
-        out.println("body.classList.remove('d-none');");
-        out.println("bindProfileForms(body);");
-        out.println("loadGeneratedBlurbs(body);");
-        out.println("var title=document.getElementById('athleteProfileModalTitle');");
-        out.println("if(title) title.textContent=athleteName + ' profile';");
-        out.println("bootstrap.Modal.getOrCreateInstance(modalElement).show();");
-        out.println("}");
-        out.println("function loadGeneratedBlurbs(root){");
-        out.println("(root || document).querySelectorAll('.ai-profile-blurb[data-ai-blurb-athlete-id]').forEach(function(card){");
-        out.println("if(card.dataset.aiLoaded==='true' || card.closest('.athlete-profile-modal-body.d-none')) return;");
-        out.println("card.dataset.aiLoaded='true';");
-        out.println("var url=card.getAttribute('data-ai-blurb-url');");
-        out.println("var textTarget=card.querySelector('[data-ai-blurb-text]');");
-        out.println("var textarea=card.querySelector('textarea[name=\"summaryText\"]');");
-        out.println("var submit=card.querySelector('button[type=\"submit\"]');");
-        out.println("var request=new XMLHttpRequest();");
-        out.println("request.open('GET', url, true);");
-        out.println("request.onreadystatechange=function(){");
-        out.println("if(request.readyState!==4) return;");
-        out.println("var text='Could not generate a profile summary right now. Very mysterious, probably cardio-related.';");
-        out.println("if(request.status>=200 && request.status<300){try{text=JSON.parse(request.responseText).text || text;}catch(e){}}");
-        out.println("if(textTarget) textTarget.textContent=text;");
-        out.println("if(textarea){textarea.value=text;textarea.disabled=false;}");
-        out.println("if(textarea){var form=textarea.closest('form[data-profile-form]');if(form){form.dataset.initial='';updateProfileButton(form);}}");
-        out.println("if(submit && !textarea) submit.disabled=false;");
-        out.println("};");
-        out.println("request.send();");
-        out.println("});");
-        out.println("}");
-        out.println("function bindProfileForms(root){");
-        out.println("(root || document).querySelectorAll('form[data-profile-form]').forEach(function(form){");
-        out.println("if(form.dataset.bound==='true') return;");
-        out.println("form.dataset.bound='true';");
-        out.println("var textarea=form.querySelector('textarea[name=\"summaryText\"]');");
-        out.println("if(textarea && form.dataset.initial===undefined){form.dataset.initial=textarea.value;}");
-        out.println("if(textarea){textarea.addEventListener('input',function(){updateProfileButton(form);});}");
-        out.println("updateProfileButton(form);");
-        out.println("});");
-        out.println("}");
-        out.println("function updateProfileButton(form){");
-        out.println("var textarea=form.querySelector('textarea[name=\"summaryText\"]');");
-        out.println("var submit=form.querySelector('button[type=\"submit\"]');");
-        out.println("if(!textarea || !submit) return;");
-        out.println("submit.disabled=textarea.disabled || textarea.value===(form.dataset.initial || '');");
-        out.println("}");
-        out.println("bindProfileForms(document);");
-        out.println("loadGeneratedBlurbs(document);");
-        out.println("})();");
-        out.println("</script>");
-    }
-
     private void renderProfileContent(PrintWriter out, CompetitionInsights.AthleteProfileSummary profile, AthleteProfileBlurb blurb, String loggedInAthleteId, String profileSummaryAction, String profileSummaryGenerateUrl) {
         out.println("<div class='d-flex align-items-center gap-3 mb-3'>");
         if (profile.profileMedium() != null && !profile.profileMedium().isBlank()) {
@@ -290,7 +294,8 @@ public class InsightsServlet extends BootcampServlet {
         renderProfileBlurb(out, profile, blurb, loggedInAthleteId, profileSummaryAction, profileSummaryGenerateUrl);
         out.println("<div class='row g-3'>");
         metric(out, "Overall rank", "#" + profile.overallRank());
-        metric(out, "Total points", format(profile.totalScore()));
+        metric(out, "Points to current week", format(profile.totalScore()));
+        metric(out, "Current week progress", format(profile.currentWeekPercentOfGoal() * 100) + "%");
         metric(out, "Active weeks", String.valueOf(profile.activeWeeks()));
         metric(out, "Goal-crusher weeks", String.valueOf(profile.goalCrushWeeks()));
         metric(out, "Sick weeks", String.valueOf(profile.sickWeeks()));
@@ -343,22 +348,6 @@ public class InsightsServlet extends BootcampServlet {
         out.println("</div>");
         out.println("<p class='mb-0' data-ai-blurb-text>Generating performance summary...</p>");
         out.println("</div></div>");
-    }
-
-    private Map<String, AthleteProfileBlurb> profileBlurbs(CompetitionInsights insights) {
-        Map<String, AthleteProfileBlurb> blurbs = new LinkedHashMap<>();
-        for (CompetitionInsights.AthleteProfileSummary profile : insights.athleteProfiles()) {
-            AthleteProfileBlurb verified = null;
-            try {
-                verified = dbService.getVerifiedAthleteProfileBlurb(profile.athleteId());
-            } catch (SQLException e) {
-                log.warn("Could not load verified athlete profile blurb for " + profile.athleteId(), e);
-            }
-            if (verified != null) {
-                blurbs.put(profile.athleteId(), verified);
-            }
-        }
-        return blurbs;
     }
 
     private void metric(PrintWriter out, String label, String value) {
@@ -437,5 +426,18 @@ public class InsightsServlet extends BootcampServlet {
 
     private String escapeAttribute(String value) {
         return escape(value).replace("'", "&#39;");
+    }
+
+    private String jsString(String value) {
+        String safe = value == null ? "" : value;
+        return "'" + safe
+                .replace("\\", "\\\\")
+                .replace("'", "\\'")
+                .replace("\r", "\\r")
+                .replace("\n", "\\n") + "'";
+    }
+
+    private String trimToEmpty(String value) {
+        return value == null ? "" : value.trim();
     }
 }

--- a/src/main/java/com/frankies/bootcamp/servlet/InviteServlet.java
+++ b/src/main/java/com/frankies/bootcamp/servlet/InviteServlet.java
@@ -1,0 +1,48 @@
+package com.frankies.bootcamp.servlet;
+
+import com.frankies.bootcamp.model.CompetitionInvitationView;
+import com.frankies.bootcamp.service.AuthSessionService;
+import com.frankies.bootcamp.service.CompetitionInvitationService;
+import com.frankies.bootcamp.service.AuthService;
+import jakarta.inject.Inject;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.jboss.logging.Logger;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+@WebServlet(name = "invite", value = "/invite")
+public class InviteServlet extends jakarta.servlet.http.HttpServlet {
+    private static final Logger log = Logger.getLogger(InviteServlet.class);
+
+    @Inject
+    private CompetitionInvitationService competitionInvitationService;
+    @Inject
+    private AuthSessionService authSessionService;
+    @Inject
+    private AuthService authService;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException, ServletException {
+        String token = req.getParameter("token");
+        if (token != null && !token.isBlank()) {
+            log.debugf("Invite page token received token=%s", token);
+            authSessionService.setPendingInvitationToken(req, token.trim());
+        }
+
+        try {
+            CompetitionInvitationView invitation = competitionInvitationService.resolveInvitationToken(authSessionService.getPendingInvitationToken(req));
+            log.debugf("Invite page resolved invitation=%s authenticated=%s", invitation == null ? "null" : invitation.getId(), authSessionService.getAuthenticatedUser(req) != null);
+            req.setAttribute("invitation", invitation);
+            if (invitation != null && !invitation.isPending()) {
+                req.setAttribute("inviteError", "This invitation is no longer available.");
+            }
+            req.getRequestDispatcher("/invite.jsp").forward(req, resp);
+        } catch (SQLException e) {
+            throw new ServletException("Unable to load invitation", e);
+        }
+    }
+}

--- a/src/main/java/com/frankies/bootcamp/servlet/InviteServlet.java
+++ b/src/main/java/com/frankies/bootcamp/servlet/InviteServlet.java
@@ -13,6 +13,9 @@ import org.jboss.logging.Logger;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 
 @WebServlet(name = "invite", value = "/invite")
 public class InviteServlet extends jakarta.servlet.http.HttpServlet {
@@ -27,7 +30,7 @@ public class InviteServlet extends jakarta.servlet.http.HttpServlet {
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException, ServletException {
-        String token = req.getParameter("token");
+        String token = extractInvitationToken(req.getParameter("token"));
         if (token != null && !token.isBlank()) {
             log.debugf("Invite page token received token=%s", token);
             authSessionService.setPendingInvitationToken(req, token.trim());
@@ -44,5 +47,54 @@ public class InviteServlet extends jakarta.servlet.http.HttpServlet {
         } catch (SQLException e) {
             throw new ServletException("Unable to load invitation", e);
         }
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        String token = extractInvitationToken(req.getParameter("token"));
+        if (token == null || token.isBlank()) {
+            resp.sendRedirect(req.getContextPath() + "/invite");
+            return;
+        }
+        authSessionService.setPendingInvitationToken(req, token.trim());
+        resp.sendRedirect(req.getContextPath() + "/invite?token=" + java.net.URLEncoder.encode(token.trim(), java.nio.charset.StandardCharsets.UTF_8));
+    }
+
+    private String extractInvitationToken(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        String trimmed = value.trim();
+        if (!trimmed.contains("://") && !trimmed.contains("token=")) {
+            return trimmed;
+        }
+        try {
+            URI uri = URI.create(trimmed);
+            String query = uri.getQuery();
+            if (query == null || query.isBlank()) {
+                return trimmed;
+            }
+            for (String part : query.split("&")) {
+                int equals = part.indexOf('=');
+                if (equals <= 0) {
+                    continue;
+                }
+                String key = part.substring(0, equals);
+                if ("token".equalsIgnoreCase(key)) {
+                    return URLDecoder.decode(part.substring(equals + 1), StandardCharsets.UTF_8);
+                }
+            }
+        } catch (IllegalArgumentException ignored) {
+            int index = trimmed.indexOf("token=");
+            if (index >= 0) {
+                String tokenPart = trimmed.substring(index + "token=".length());
+                int end = tokenPart.indexOf('&');
+                if (end >= 0) {
+                    tokenPart = tokenPart.substring(0, end);
+                }
+                return URLDecoder.decode(tokenPart, StandardCharsets.UTF_8);
+            }
+        }
+        return trimmed;
     }
 }

--- a/src/main/java/com/frankies/bootcamp/servlet/LeaderboardServlet.java
+++ b/src/main/java/com/frankies/bootcamp/servlet/LeaderboardServlet.java
@@ -32,9 +32,9 @@ public class LeaderboardServlet extends BootcampServlet {
                 ? activityProcessFacade.getSortedSummariesForCompetition(selectedCompetitionId)
                 : activityProcessFacade.getSortedSummaries(loggedInAthlete == null ? null : loggedInAthlete.getId());
         Map<String, String> athleteIdsByName = athleteIdsByName(selectedCompetitionId);
+        Map<String, Double> yearlyScoreSummary = sortedSummaries.get(BootcampConstants.currentYearlyScoreSummary);
+        Map<String, Double> weeklyProgressSummary = sortedSummaries.get(BootcampConstants.currentWeekPercentageOfGoalSummary);
 
-        out.println("<html><head>");
-        out.println("</head><body>");
         out.println("<div class='container'>");
         out.println("<h2 class='history-heading'>");
         out.println("<i class='bi bi-trophy-fill'></i> Frankie's Bootcamp Leaderboard");
@@ -42,6 +42,7 @@ public class LeaderboardServlet extends BootcampServlet {
         out.println("<p class='history-subheading'>");
         out.println("🔥 Tracking top performers and weekly goal crushers across the challenge.");
         out.println("</p>");
+        int rank;
 
 // Accordion Buttons
         out.println("<button id='btnScore' class='accordion-button btn btn-primary active'>");
@@ -61,14 +62,18 @@ public class LeaderboardServlet extends BootcampServlet {
         out.println("<p class='history-subheading'>");
         out.println("🏅 Cumulative scores for athletes conquering the full challenge.");
         out.println("</p>");
+        if (yearlyScoreSummary == null || yearlyScoreSummary.isEmpty()) {
+            out.println("<div class='alert alert-info'>No leaderboard scores are available yet.</div>");
+            out.println("</div>");
+        } else {
         out.println("<table>");
         out.println("<thead><tr>");
         out.println("<th><i class='bi bi-person-fill'></i> Athlete</th>");
         out.println("<th><i class='bi bi-star-fill'></i> Score</th>");
         out.println("</tr></thead>");
         out.println("<tbody>");
-        int rank = 1;
-        for (Map.Entry<String, Double> entry : sortedSummaries.get(BootcampConstants.currentYearlyScoreSummary).entrySet()) {
+        rank = 1;
+        for (Map.Entry<String, Double> entry : yearlyScoreSummary.entrySet()) {
             out.println("<tr><td>" + athleteProfileLink(entry.getKey(), athleteIdsByName));
             if (rank == 1) {
                 out.println(" <i class='bi bi-trophy trophy gold' title='Gold Trophy'></i>");
@@ -83,12 +88,17 @@ public class LeaderboardServlet extends BootcampServlet {
         }
         out.println("</tbody></table>");
         out.println("</div>");
+        }
 
 // This Week Percentage Of Goal Table
         out.println("<div id='progressContent' class='accordion-content'>");
         out.println("<p class='history-subheading'>");
         out.println("📈 Who’s pushing hardest this week and smashing their personal targets.");
         out.println("</p>");
+        if (weeklyProgressSummary == null || weeklyProgressSummary.isEmpty()) {
+            out.println("<div class='alert alert-info'>No weekly progress leaderboard is available yet.</div>");
+            out.println("</div>");
+        } else {
         out.println("<table>");
         out.println("<thead><tr>");
         out.println("<th><i class='bi bi-person-fill'></i> Athlete</th>");
@@ -96,7 +106,7 @@ public class LeaderboardServlet extends BootcampServlet {
         out.println("</tr></thead>");
         out.println("<tbody>");
         rank = 1;
-        for (Map.Entry<String, Double> entry : sortedSummaries.get(BootcampConstants.currentWeekPercentageOfGoalSummary).entrySet()) {
+        for (Map.Entry<String, Double> entry : weeklyProgressSummary.entrySet()) {
             out.println("<tr><td>" + athleteProfileLink(entry.getKey(), athleteIdsByName));
             if (rank == 1) {
                 out.println(" <i class='bi bi-trophy trophy gold' title='Gold Trophy'></i>");
@@ -111,6 +121,7 @@ public class LeaderboardServlet extends BootcampServlet {
         }
         out.println("</tbody></table>");
         out.println("</div>");
+        }
 
         out.println("<script>");
         out.println("const buttons = document.querySelectorAll('.accordion-button');");
@@ -138,7 +149,7 @@ public class LeaderboardServlet extends BootcampServlet {
         out.println("});");
         out.println("</script>");
 
-        out.println("</div></body></html>");
+        out.println("</div>");
     }
 
     private Map<String, String> athleteIdsByName(Long selectedCompetitionId) {

--- a/src/main/java/com/frankies/bootcamp/servlet/ManageCompetitionsServlet.java
+++ b/src/main/java/com/frankies/bootcamp/servlet/ManageCompetitionsServlet.java
@@ -1,16 +1,112 @@
 package com.frankies.bootcamp.servlet;
 
+import com.frankies.bootcamp.model.BootcampAthlete;
+import com.frankies.bootcamp.service.AuthSessionService;
+import com.frankies.bootcamp.service.CompetitionSetupService;
+import com.frankies.bootcamp.service.DBService;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.inject.Inject;
+import org.wildfly.security.credential.store.CredentialStoreException;
+
+import java.security.NoSuchAlgorithmException;
+import java.sql.SQLException;
 
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 @WebServlet(name = "manageCompetitions", value = "/app/competitions")
 public class ManageCompetitionsServlet extends BootcampServlet {
+    @Inject
+    private AuthSessionService authSessionService;
+
+    @Inject
+    private DBService dbService;
+
+    @Inject
+    private CompetitionSetupService competitionSetupService;
+
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        try {
+            renderPage(request, response);
+        } catch (SQLException e) {
+            throw new ServletException("Unable to load competition management page", e);
+        }
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        BootcampAthlete athlete = (BootcampAthlete) request.getAttribute("athlete");
+        if (athlete == null || athlete.getId() == null || athlete.getId().isBlank()) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "A linked athlete is required.");
+            return;
+        }
+
+        String action = request.getParameter("action");
+        long competitionId;
+        try {
+            competitionId = Long.parseLong(request.getParameter("competitionId"));
+        } catch (NumberFormatException e) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Competition selection is required.");
+            return;
+        }
+
+        try {
+            if ("leave".equals(action)) {
+                if (!dbService.athleteBelongsToCompetition(athlete.getId(), competitionId)) {
+                    response.sendError(HttpServletResponse.SC_BAD_REQUEST, "You are not active in that competition.");
+                    return;
+                }
+                if (dbService.isCompetitionAdmin(competitionId, athlete.getId()) && dbService.countCompetitionAdmins(competitionId) <= 1) {
+                    response.sendRedirect(buildLeaveErrorRedirect(request.getContextPath(), "last-admin"));
+                    return;
+                }
+
+                dbService.leaveCompetition(competitionId, athlete.getId());
+                Long selectedCompetitionId = authSessionService.getSelectedCompetitionId(request);
+                if (selectedCompetitionId != null && selectedCompetitionId == competitionId) {
+                    authSessionService.setSelectedCompetitionId(request, null);
+                }
+                if (authSessionService.getSelectedCompetitionId(request) == null) {
+                    request.getSession(true).removeAttribute("selectedCompetitionId");
+                }
+            } else if ("join".equals(action)) {
+                competitionSetupService.joinCompetition(athlete, request.getParameter("competitionId"), request.getParameter("joinStartingGoal"));
+                authSessionService.setSelectedCompetitionId(request, competitionId);
+                request.getSession(true).setAttribute("selectedCompetitionId", competitionId);
+            } else {
+                response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Unsupported competition action.");
+                return;
+            }
+            response.sendRedirect(request.getContextPath() + "/app/competitions");
+        } catch (SQLException | CredentialStoreException | NoSuchAlgorithmException e) {
+            throw new ServletException("Unable to update competition membership", e);
+        }
+    }
+
+    static String buildLeaveErrorRedirect(String contextPath, String errorCode) {
+        return contextPath + "/app/competitions?leaveError=" + URLEncoder.encode(errorCode, StandardCharsets.UTF_8);
+    }
+
+    private void renderPage(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException, SQLException {
+        BootcampAthlete athlete = (BootcampAthlete) request.getAttribute("athlete");
+        if (athlete == null || athlete.getId() == null || athlete.getId().isBlank()) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "A linked athlete is required.");
+            return;
+        }
+
+        request.setAttribute("activeCompetitions", dbService.listCurrentActiveCompetitions(athlete.getId()));
+        request.setAttribute("pastCompetitions", dbService.listPastCompetitions(athlete.getId()));
+        request.setAttribute("availableCompetitions", dbService.listJoinableCompetitions(athlete.getId()));
+        Long selectedCompetitionId = authSessionService.getSelectedCompetitionId(request);
+        request.setAttribute("selectedCompetitionAdmin", selectedCompetitionId != null && dbService.isCompetitionAdmin(selectedCompetitionId, athlete.getId()));
+        request.getSession(true).setAttribute("activeCompetitions", request.getAttribute("activeCompetitions"));
+        request.getSession(true).setAttribute("pastCompetitions", request.getAttribute("pastCompetitions"));
+        request.getSession(true).setAttribute("selectedCompetitionId", selectedCompetitionId);
         request.getRequestDispatcher("/app/competition-selection.jsp").forward(request, response);
     }
 }

--- a/src/main/java/com/frankies/bootcamp/servlet/TabAuditServlet.java
+++ b/src/main/java/com/frankies/bootcamp/servlet/TabAuditServlet.java
@@ -13,7 +13,7 @@ import java.util.Set;
 
 @WebServlet(name = "tabAudit", value = "/app/TabAudit")
 public class TabAuditServlet extends BootcampServlet {
-    private static final Set<String> ALLOWED_TABS = Set.of("landing", "history", "leaderboard", "honour-roll", "summary", "insights");
+    private static final Set<String> ALLOWED_TABS = Set.of("landing", "history", "leaderboard", "honour-roll", "insights", "help");
 
     @Inject
     private DBService dbService;

--- a/src/main/java/com/frankies/bootcamp/util/EmailDisplayUtil.java
+++ b/src/main/java/com/frankies/bootcamp/util/EmailDisplayUtil.java
@@ -1,0 +1,22 @@
+package com.frankies.bootcamp.util;
+
+public final class EmailDisplayUtil {
+    private EmailDisplayUtil() {
+    }
+
+    public static String maskEmail(String email) {
+        if (email == null || email.isBlank()) {
+            return "";
+        }
+        int at = email.indexOf('@');
+        if (at <= 0 || at == email.length() - 1) {
+            return email;
+        }
+        String localPart = email.substring(0, at);
+        String domain = email.substring(at);
+        if (localPart.length() <= 2) {
+            return localPart.substring(0, 1) + "***" + domain;
+        }
+        return localPart.substring(0, 1) + "***" + localPart.substring(localPart.length() - 1) + domain;
+    }
+}

--- a/src/main/webapp/WEB-INF/jspf/head-common.jspf
+++ b/src/main/webapp/WEB-INF/jspf/head-common.jspf
@@ -51,28 +51,29 @@
         function show(message) {
             clearTimeout(showTimer);
             clearTimeout(slowTimer);
-            showTimer = setTimeout(function () {
-                const overlay = ensureOverlay();
-                if (!overlay) return;
-                const messageEl = document.getElementById('appLoadingMessage');
-                if (messageEl) messageEl.textContent = message || 'Loading...';
-                overlay.classList.remove('is-slow');
-                overlay.classList.add('is-visible');
-                slowTimer = setTimeout(function () {
-                    const slowMessageEl = document.getElementById('appLoadingMessage');
-                    if (slowMessageEl) {
-                        slowMessageEl.textContent = 'This rebuild can take a few minutes. You can keep browsing and come back shortly.';
-                    }
-                    overlay.classList.add('is-slow');
-                }, 8000);
-            }, 120);
+            const overlay = ensureOverlay();
+            if (!overlay) return;
+            const messageEl = document.getElementById('appLoadingMessage');
+            if (messageEl) messageEl.textContent = message || 'Loading...';
+            overlay.classList.remove('is-slow');
+            overlay.classList.add('is-visible');
+            slowTimer = setTimeout(function () {
+                const slowMessageEl = document.getElementById('appLoadingMessage');
+                if (slowMessageEl) {
+                    slowMessageEl.textContent = 'This rebuild can take a few minutes. You can keep browsing and come back shortly.';
+                }
+                overlay.classList.add('is-slow');
+            }, 8000);
         }
 
         function hide() {
             clearTimeout(showTimer);
             clearTimeout(slowTimer);
+            pendingRequests = 0;
             const overlay = document.getElementById('appLoadingOverlay');
-            if (overlay) overlay.classList.remove('is-visible', 'is-slow');
+            if (overlay) {
+                overlay.classList.remove('is-visible', 'is-slow');
+            }
         }
 
         window.bootcampLoading = { show: show, hide: hide };
@@ -80,9 +81,14 @@
         if (window.fetch) {
             const originalFetch = window.fetch.bind(window);
             window.fetch = function () {
+                const args = arguments;
+                const options = args[1] || {};
+                if (options && options.loadingOverlay === false) {
+                    return originalFetch.apply(window, args);
+                }
                 pendingRequests++;
                 show('Loading...');
-                return originalFetch.apply(window, arguments).finally(function () {
+                return originalFetch.apply(window, args).finally(function () {
                     pendingRequests = Math.max(0, pendingRequests - 1);
                     if (pendingRequests === 0) hide();
                 });
@@ -102,14 +108,28 @@
             }
             if (url.origin !== window.location.origin || url.protocol !== window.location.protocol) return;
 
+            event.preventDefault();
             show(link.href.includes('/app/select-competition') ? 'Switching competition...' : 'Loading...');
+            window.setTimeout(function () {
+                window.location.href = link.href;
+            }, link.href.includes('/app/select-competition') ? 120 : 80);
         }, true);
 
         document.addEventListener('submit', function (event) {
             if (event.defaultPrevented) return;
             const form = event.target;
-            if (form && typeof form.checkValidity === 'function' && !form.checkValidity()) return;
-            show('Saving...');
-        }, true);
+            if (!form || !form.dataset || form.dataset.loadingSubmit !== 'true') return;
+            if (typeof form.checkValidity === 'function' && !form.checkValidity()) return;
+
+            event.preventDefault();
+            show(form.dataset.loadingMessage || 'Saving...');
+            window.requestAnimationFrame(function () {
+                form.submit();
+            });
+        });
+
+        window.addEventListener('pageshow', function () {
+            hide();
+        });
     })();
 </script>

--- a/src/main/webapp/WEB-INF/jspf/header.jspf
+++ b/src/main/webapp/WEB-INF/jspf/header.jspf
@@ -10,9 +10,32 @@
     List<CompetitionSummaryView> activeCompetitions = activeCompetitionsAttr instanceof List<?> ? (List<CompetitionSummaryView>) activeCompetitionsAttr : List.of();
     Object pastCompetitionsAttr = request.getAttribute("pastCompetitions");
     List<CompetitionSummaryView> pastCompetitions = pastCompetitionsAttr instanceof List<?> ? (List<CompetitionSummaryView>) pastCompetitionsAttr : List.of();
+    Object pendingCompetitionInvitationsAttr = request.getAttribute("pendingCompetitionInvitations");
+    List<?> pendingCompetitionInvitations = pendingCompetitionInvitationsAttr instanceof List<?> ? (List<?>) pendingCompetitionInvitationsAttr : List.of();
+    Object selectedCompetitionAdminAttr = request.getAttribute("selectedCompetitionAdmin");
+    boolean selectedCompetitionAdmin = selectedCompetitionAdminAttr instanceof Boolean && (Boolean) selectedCompetitionAdminAttr;
     int activeMenuCount = Math.min(activeCompetitions.size(), 5);
     int recentMenuCount = Math.min(pastCompetitions.size(), 3);
 %>
+<style>
+    .user-avatar {
+        width: 28px;
+        height: 28px;
+        border-radius: 50%;
+        object-fit: cover;
+        background: rgba(255, 255, 255, 0.18);
+    }
+
+    .user-avatar-placeholder {
+        width: 28px;
+        height: 28px;
+        border-radius: 50%;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        background: rgba(255, 255, 255, 0.18);
+    }
+</style>
 
 <header class="d-flex align-items-center justify-content-between text-white px-3 py-2 shadow-sm"
         style="min-height:56px; position: sticky; top: 0; z-index: 1030; background-color: #0d6efd;">
@@ -98,6 +121,16 @@
                         <% } %>
                         <% } %>
                         <% } %>
+                        <% if (inApp && !pendingCompetitionInvitations.isEmpty()) { %>
+                        <a class="btn btn-warning mb-2" href="<%=ctx%>/app/invitations">
+                            <i class="bi bi-envelope-paper me-1"></i> Invitations (<%= pendingCompetitionInvitations.size() %>)
+                        </a>
+                        <% } %>
+                        <% if (inApp && selectedCompetitionAdmin && selectedCompetitionId != null) { %>
+                        <a class="btn btn-outline-warning mb-2" href="<%=ctx%>/app/competition-invitations?competitionId=<%= selectedCompetitionId %>">
+                            <i class="bi bi-person-plus me-1"></i> Manage invites
+                        </a>
+                        <% } %>
 
                         <button id="linkStravaBtn" class="btn btn-outline-primary d-none" onclick="linkStravaPopup()">
                             <i class="bi bi-link-45deg me-1"></i> Link Strava
@@ -117,7 +150,10 @@
     </h1>
     <!-- Signed-in user chip -->
     <span id="userChip" class="user-chip d-none ms-2">
-        <i class="bi bi-person-circle me-1" aria-hidden="true"></i>
+        <span id="userAvatarWrap" class="me-1 d-none" aria-hidden="true">
+            <img id="userAvatarImg" class="user-avatar" alt="">
+            <span id="userAvatarPlaceholder" class="user-avatar-placeholder d-none"><i class="bi bi-person"></i></span>
+        </span>
         <span id="userName"></span>
     </span>
 </header>
@@ -137,7 +173,7 @@
 <script>
     (function () {
         const ctx = '<%=ctx%>';
-        const state = { authed: false, name: '', email: '', stravaLinked: false };
+        const state = { authed: false, name: '', email: '', stravaLinked: false, profileMedium: '' };
 
         async function fetchAuth() {
             try {
@@ -158,6 +194,7 @@
                         state.name = d.name || '';
                         state.email = d.email || '';
                         state.stravaLinked = d.stravaLinked === true;
+                        state.profileMedium = d.profileMedium || '';
                     } else {
                         setLoggedOut();
                     }
@@ -170,7 +207,7 @@
             render();
         }
 
-        function setLoggedOut() { state.authed = false; state.name = ''; state.email = ''; state.stravaLinked = false; }
+        function setLoggedOut() { state.authed = false; state.name = ''; state.email = ''; state.stravaLinked = false; state.profileMedium = ''; }
 
         function render() {
             const group = document.querySelector('#offcanvasMenu .btn-group-vertical');
@@ -181,11 +218,27 @@
             const linkBtn   = document.getElementById('linkStravaBtn');   // <--
             const signedInAs    = document.getElementById('signedInAs');
             const signedInName  = document.getElementById('signedInName');
+            const userAvatarWrap = document.getElementById('userAvatarWrap');
+            const userAvatarImg = document.getElementById('userAvatarImg');
+            const userAvatarPlaceholder = document.getElementById('userAvatarPlaceholder');
 
             if (state.authed) {
                 if (signedInAs) {
                     signedInAs.classList.remove('d-none');
                     signedInName && (signedInName.textContent = state.name || state.email || 'You');
+                }
+                if (userAvatarWrap) {
+                    userAvatarWrap.classList.remove('d-none');
+                    if (state.profileMedium) {
+                        if (userAvatarImg) {
+                            userAvatarImg.src = state.profileMedium;
+                            userAvatarImg.classList.remove('d-none');
+                        }
+                        userAvatarPlaceholder && userAvatarPlaceholder.classList.add('d-none');
+                    } else {
+                        userAvatarImg && userAvatarImg.classList.add('d-none');
+                        userAvatarPlaceholder && userAvatarPlaceholder.classList.remove('d-none');
+                    }
                 }
                 if (loginBtn) {
                     loginBtn.innerHTML = '<i class="bi bi-speedometer2 me-1"></i> Go to dashboard';
@@ -201,6 +254,7 @@
                 }
             } else {
                 if (signedInAs) signedInAs.classList.add('d-none');
+                if (userAvatarWrap) userAvatarWrap.classList.add('d-none');
                 if (loginBtn) {
                     loginBtn.innerHTML = '<i class="bi bi-box-arrow-in-right me-1"></i> Login';
                     loginBtn.href = ctx + '/login';

--- a/src/main/webapp/WEB-INF/jspf/header.jspf
+++ b/src/main/webapp/WEB-INF/jspf/header.jspf
@@ -1,5 +1,6 @@
 <%@ page import="com.frankies.bootcamp.model.CompetitionSummaryView" %>
 <%@ page import="java.util.List" %>
+<%@ page import="java.util.Set" %>
 <%
     String ctx = request.getContextPath();
     boolean inApp = request.getRequestURI().startsWith(ctx + "/app");
@@ -14,8 +15,9 @@
     List<?> pendingCompetitionInvitations = pendingCompetitionInvitationsAttr instanceof List<?> ? (List<?>) pendingCompetitionInvitationsAttr : List.of();
     Object selectedCompetitionAdminAttr = request.getAttribute("selectedCompetitionAdmin");
     boolean selectedCompetitionAdmin = selectedCompetitionAdminAttr instanceof Boolean && (Boolean) selectedCompetitionAdminAttr;
-    int activeMenuCount = Math.min(activeCompetitions.size(), 5);
-    int recentMenuCount = Math.min(pastCompetitions.size(), 3);
+    Object competitionSetupAllowedAttr = request.getAttribute("competitionSetupAllowed");
+    boolean competitionSetupAllowed = competitionSetupAllowedAttr instanceof Boolean && (Boolean) competitionSetupAllowedAttr;
+    Set<Long> activeCompetitionIds = activeCompetitions.stream().map(CompetitionSummaryView::getId).collect(java.util.stream.Collectors.toSet());
 %>
 <style>
     .user-avatar {
@@ -97,36 +99,54 @@
                             <i class="bi bi-shield-lock me-1"></i> Privacy Policy
                         </a>
 
-                        <% if (inApp && (!activeCompetitions.isEmpty() || !pastCompetitions.isEmpty())) { %>
-                        <% if (!activeCompetitions.isEmpty()) { %>
-                        <div class="mt-3 mb-2 text-muted small">Current competitions</div>
-                        <% for (int i = 0; i < activeMenuCount; i++) {
-                            CompetitionSummaryView competition = activeCompetitions.get(i);
-                        %>
-                        <a class="btn <%= selectedCompetitionId != null && selectedCompetitionId == competition.getId() ? "btn-primary" : "btn-outline-primary" %> mb-2"
-                           href="<%=ctx%>/app/select-competition?competitionId=<%= competition.getId() %>&returnTo=/app/">
-                            <i class="bi bi-flag me-1"></i> <%= competition.getName() %>
+                        <% if (inApp && !activeCompetitions.isEmpty()) { %>
+                        <div class="dropdown mt-3 mb-2">
+                            <button class="btn btn-outline-primary dropdown-toggle w-100 text-start" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+                                <i class="bi bi-flag me-1"></i> Current competitions (<%= activeCompetitions.size() %>)
+                            </button>
+                            <ul class="dropdown-menu w-100" style="max-height: 18rem; overflow-y: auto;">
+                                <% for (CompetitionSummaryView competition : activeCompetitions) { %>
+                                <li>
+                                    <a class="dropdown-item <%= selectedCompetitionId != null && selectedCompetitionId == competition.getId() ? "active" : "" %>"
+                                       href="<%=ctx%>/app/select-competition?competitionId=<%= competition.getId() %>&returnTo=/app/">
+                                        <%= competition.getName() %>
+                                    </a>
+                                </li>
+                                <% } %>
+                            </ul>
+                        </div>
+                        <% } %>
+                        <% if (inApp && !pastCompetitions.isEmpty()) { %>
+                        <div class="dropdown mb-2">
+                            <button class="btn btn-outline-secondary dropdown-toggle w-100 text-start" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+                                <i class="bi bi-clock-history me-1"></i> Past competitions (<%= pastCompetitions.size() %>)
+                            </button>
+                            <ul class="dropdown-menu w-100" style="max-height: 14rem; overflow-y: auto;">
+                                <% for (CompetitionSummaryView competition : pastCompetitions) { %>
+                                <li>
+                                    <a class="dropdown-item <%= selectedCompetitionId != null && selectedCompetitionId == competition.getId() ? "active" : "" %>"
+                                       href="<%=ctx%>/app/select-competition?competitionId=<%= competition.getId() %>&returnTo=/app/">
+                                        <%= competition.getName() %>
+                                    </a>
+                                </li>
+                                <% } %>
+                            </ul>
+                        </div>
+                        <% } %>
+                        <% if (inApp && Boolean.TRUE.equals(competitionSetupAllowed)) { %>
+                        <a class="btn btn-outline-primary mb-2" href="<%=ctx%>/app/competitions">
+                            <i class="bi bi-list-check me-1"></i> Manage competitions
                         </a>
-                        <% } %>
-                        <% } %>
-                        <% if (!pastCompetitions.isEmpty()) { %>
-                        <div class="mt-3 mb-2 text-muted small">Recently finished</div>
-                        <% for (int i = 0; i < recentMenuCount; i++) {
-                            CompetitionSummaryView competition = pastCompetitions.get(i);
-                        %>
-                        <a class="btn <%= selectedCompetitionId != null && selectedCompetitionId == competition.getId() ? "btn-primary" : "btn-outline-secondary" %> mb-2"
-                           href="<%=ctx%>/app/select-competition?competitionId=<%= competition.getId() %>&returnTo=/app/">
-                            <i class="bi bi-clock-history me-1"></i> <%= competition.getName() %>
+                        <a class="btn btn-outline-secondary mb-2" href="<%=ctx%>/app/competition-setup">
+                            <i class="bi bi-plus-circle me-1"></i> Create or join competition
                         </a>
-                        <% } %>
-                        <% } %>
                         <% } %>
                         <% if (inApp && !pendingCompetitionInvitations.isEmpty()) { %>
                         <a class="btn btn-warning mb-2" href="<%=ctx%>/app/invitations">
                             <i class="bi bi-envelope-paper me-1"></i> Invitations (<%= pendingCompetitionInvitations.size() %>)
                         </a>
                         <% } %>
-                        <% if (inApp && selectedCompetitionAdmin && selectedCompetitionId != null) { %>
+                        <% if (inApp && selectedCompetitionAdmin && selectedCompetitionId != null && activeCompetitionIds.contains(selectedCompetitionId)) { %>
                         <a class="btn btn-outline-warning mb-2" href="<%=ctx%>/app/competition-invitations?competitionId=<%= selectedCompetitionId %>">
                             <i class="bi bi-person-plus me-1"></i> Manage invites
                         </a>

--- a/src/main/webapp/WEB-INF/jspf/header.jspf
+++ b/src/main/webapp/WEB-INF/jspf/header.jspf
@@ -5,19 +5,19 @@
     String ctx = request.getContextPath();
     boolean inApp = request.getRequestURI().startsWith(ctx + "/app");
     String brandHref = inApp ? ctx + "/app/" : ctx + "/";
-    Object selectedCompetitionIdAttr = request.getAttribute("selectedCompetitionId");
-    Long selectedCompetitionId = selectedCompetitionIdAttr instanceof Long ? (Long) selectedCompetitionIdAttr : null;
-    Object activeCompetitionsAttr = request.getAttribute("activeCompetitions");
-    List<CompetitionSummaryView> activeCompetitions = activeCompetitionsAttr instanceof List<?> ? (List<CompetitionSummaryView>) activeCompetitionsAttr : List.of();
-    Object pastCompetitionsAttr = request.getAttribute("pastCompetitions");
-    List<CompetitionSummaryView> pastCompetitions = pastCompetitionsAttr instanceof List<?> ? (List<CompetitionSummaryView>) pastCompetitionsAttr : List.of();
-    Object pendingCompetitionInvitationsAttr = request.getAttribute("pendingCompetitionInvitations");
-    List<?> pendingCompetitionInvitations = pendingCompetitionInvitationsAttr instanceof List<?> ? (List<?>) pendingCompetitionInvitationsAttr : List.of();
-    Object selectedCompetitionAdminAttr = request.getAttribute("selectedCompetitionAdmin");
-    boolean selectedCompetitionAdmin = selectedCompetitionAdminAttr instanceof Boolean && (Boolean) selectedCompetitionAdminAttr;
-    Object competitionSetupAllowedAttr = request.getAttribute("competitionSetupAllowed");
-    boolean competitionSetupAllowed = competitionSetupAllowedAttr instanceof Boolean && (Boolean) competitionSetupAllowedAttr;
-    Set<Long> activeCompetitionIds = activeCompetitions.stream().map(CompetitionSummaryView::getId).collect(java.util.stream.Collectors.toSet());
+    Object headerSelectedCompetitionIdAttr = request.getAttribute("selectedCompetitionId");
+    Long headerSelectedCompetitionId = headerSelectedCompetitionIdAttr instanceof Long ? (Long) headerSelectedCompetitionIdAttr : null;
+    Object headerActiveCompetitionsAttr = request.getAttribute("activeCompetitions");
+    List<CompetitionSummaryView> headerActiveCompetitions = headerActiveCompetitionsAttr instanceof List<?> ? (List<CompetitionSummaryView>) headerActiveCompetitionsAttr : List.of();
+    Object headerPastCompetitionsAttr = request.getAttribute("pastCompetitions");
+    List<CompetitionSummaryView> headerPastCompetitions = headerPastCompetitionsAttr instanceof List<?> ? (List<CompetitionSummaryView>) headerPastCompetitionsAttr : List.of();
+    Object headerPendingCompetitionInvitationsAttr = request.getAttribute("pendingCompetitionInvitations");
+    List<?> headerPendingCompetitionInvitations = headerPendingCompetitionInvitationsAttr instanceof List<?> ? (List<?>) headerPendingCompetitionInvitationsAttr : List.of();
+    Object headerSelectedCompetitionAdminAttr = request.getAttribute("selectedCompetitionAdmin");
+    boolean headerSelectedCompetitionAdmin = headerSelectedCompetitionAdminAttr instanceof Boolean && (Boolean) headerSelectedCompetitionAdminAttr;
+    Object headerCompetitionSetupAllowedAttr = request.getAttribute("competitionSetupAllowed");
+    boolean headerCompetitionSetupAllowed = headerCompetitionSetupAllowedAttr instanceof Boolean && (Boolean) headerCompetitionSetupAllowedAttr;
+    Set<Long> headerActiveCompetitionIds = headerActiveCompetitions.stream().map(CompetitionSummaryView::getId).collect(java.util.stream.Collectors.toSet());
 %>
 <style>
     .user-avatar {
@@ -99,15 +99,15 @@
                             <i class="bi bi-shield-lock me-1"></i> Privacy Policy
                         </a>
 
-                        <% if (inApp && !activeCompetitions.isEmpty()) { %>
+                        <% if (inApp && !headerActiveCompetitions.isEmpty()) { %>
                         <div class="dropdown mt-3 mb-2">
                             <button class="btn btn-outline-primary dropdown-toggle w-100 text-start" type="button" data-bs-toggle="dropdown" aria-expanded="false">
-                                <i class="bi bi-flag me-1"></i> Current competitions (<%= activeCompetitions.size() %>)
+                                <i class="bi bi-flag me-1"></i> Current competitions (<%= headerActiveCompetitions.size() %>)
                             </button>
                             <ul class="dropdown-menu w-100" style="max-height: 18rem; overflow-y: auto;">
-                                <% for (CompetitionSummaryView competition : activeCompetitions) { %>
+                                <% for (CompetitionSummaryView competition : headerActiveCompetitions) { %>
                                 <li>
-                                    <a class="dropdown-item <%= selectedCompetitionId != null && selectedCompetitionId == competition.getId() ? "active" : "" %>"
+                                    <a class="dropdown-item <%= headerSelectedCompetitionId != null && headerSelectedCompetitionId == competition.getId() ? "active" : "" %>"
                                        href="<%=ctx%>/app/select-competition?competitionId=<%= competition.getId() %>&returnTo=/app/">
                                         <%= competition.getName() %>
                                     </a>
@@ -116,15 +116,15 @@
                             </ul>
                         </div>
                         <% } %>
-                        <% if (inApp && !pastCompetitions.isEmpty()) { %>
+                        <% if (inApp && !headerPastCompetitions.isEmpty()) { %>
                         <div class="dropdown mb-2">
                             <button class="btn btn-outline-secondary dropdown-toggle w-100 text-start" type="button" data-bs-toggle="dropdown" aria-expanded="false">
-                                <i class="bi bi-clock-history me-1"></i> Past competitions (<%= pastCompetitions.size() %>)
+                                <i class="bi bi-clock-history me-1"></i> Past competitions (<%= headerPastCompetitions.size() %>)
                             </button>
                             <ul class="dropdown-menu w-100" style="max-height: 14rem; overflow-y: auto;">
-                                <% for (CompetitionSummaryView competition : pastCompetitions) { %>
+                                <% for (CompetitionSummaryView competition : headerPastCompetitions) { %>
                                 <li>
-                                    <a class="dropdown-item <%= selectedCompetitionId != null && selectedCompetitionId == competition.getId() ? "active" : "" %>"
+                                    <a class="dropdown-item <%= headerSelectedCompetitionId != null && headerSelectedCompetitionId == competition.getId() ? "active" : "" %>"
                                        href="<%=ctx%>/app/select-competition?competitionId=<%= competition.getId() %>&returnTo=/app/">
                                         <%= competition.getName() %>
                                     </a>
@@ -133,7 +133,7 @@
                             </ul>
                         </div>
                         <% } %>
-                        <% if (inApp && Boolean.TRUE.equals(competitionSetupAllowed)) { %>
+                        <% if (inApp && Boolean.TRUE.equals(headerCompetitionSetupAllowed)) { %>
                         <a class="btn btn-outline-primary mb-2" href="<%=ctx%>/app/competitions">
                             <i class="bi bi-list-check me-1"></i> Manage competitions
                         </a>
@@ -141,13 +141,13 @@
                             <i class="bi bi-plus-circle me-1"></i> Create or join competition
                         </a>
                         <% } %>
-                        <% if (inApp && !pendingCompetitionInvitations.isEmpty()) { %>
+                        <% if (inApp && !headerPendingCompetitionInvitations.isEmpty()) { %>
                         <a class="btn btn-warning mb-2" href="<%=ctx%>/app/invitations">
-                            <i class="bi bi-envelope-paper me-1"></i> Invitations (<%= pendingCompetitionInvitations.size() %>)
+                            <i class="bi bi-envelope-paper me-1"></i> Invitations (<%= headerPendingCompetitionInvitations.size() %>)
                         </a>
                         <% } %>
-                        <% if (inApp && selectedCompetitionAdmin && selectedCompetitionId != null && activeCompetitionIds.contains(selectedCompetitionId)) { %>
-                        <a class="btn btn-outline-warning mb-2" href="<%=ctx%>/app/competition-invitations?competitionId=<%= selectedCompetitionId %>">
+                        <% if (inApp && headerSelectedCompetitionAdmin && headerSelectedCompetitionId != null && headerActiveCompetitionIds.contains(headerSelectedCompetitionId)) { %>
+                        <a class="btn btn-outline-warning mb-2" href="<%=ctx%>/app/competition-invitations?competitionId=<%= headerSelectedCompetitionId %>">
                             <i class="bi bi-person-plus me-1"></i> Manage invites
                         </a>
                         <% } %>

--- a/src/main/webapp/WEB-INF/jspf/header.jspf
+++ b/src/main/webapp/WEB-INF/jspf/header.jspf
@@ -1,3 +1,5 @@
+<%@ page import="com.frankies.bootcamp.model.AuthenticatedUser" %>
+<%@ page import="com.frankies.bootcamp.model.BootcampAthlete" %>
 <%@ page import="com.frankies.bootcamp.model.CompetitionSummaryView" %>
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.Set" %>
@@ -6,18 +8,51 @@
     boolean inApp = request.getRequestURI().startsWith(ctx + "/app");
     String brandHref = inApp ? ctx + "/app/" : ctx + "/";
     Object headerSelectedCompetitionIdAttr = request.getAttribute("selectedCompetitionId");
+    if (headerSelectedCompetitionIdAttr == null) {
+        headerSelectedCompetitionIdAttr = session.getAttribute("selectedCompetitionId");
+    }
     Long headerSelectedCompetitionId = headerSelectedCompetitionIdAttr instanceof Long ? (Long) headerSelectedCompetitionIdAttr : null;
     Object headerActiveCompetitionsAttr = request.getAttribute("activeCompetitions");
+    if (headerActiveCompetitionsAttr == null) {
+        headerActiveCompetitionsAttr = session.getAttribute("activeCompetitions");
+    }
     List<CompetitionSummaryView> headerActiveCompetitions = headerActiveCompetitionsAttr instanceof List<?> ? (List<CompetitionSummaryView>) headerActiveCompetitionsAttr : List.of();
     Object headerPastCompetitionsAttr = request.getAttribute("pastCompetitions");
+    if (headerPastCompetitionsAttr == null) {
+        headerPastCompetitionsAttr = session.getAttribute("pastCompetitions");
+    }
     List<CompetitionSummaryView> headerPastCompetitions = headerPastCompetitionsAttr instanceof List<?> ? (List<CompetitionSummaryView>) headerPastCompetitionsAttr : List.of();
     Object headerPendingCompetitionInvitationsAttr = request.getAttribute("pendingCompetitionInvitations");
     List<?> headerPendingCompetitionInvitations = headerPendingCompetitionInvitationsAttr instanceof List<?> ? (List<?>) headerPendingCompetitionInvitationsAttr : List.of();
     Object headerSelectedCompetitionAdminAttr = request.getAttribute("selectedCompetitionAdmin");
+    if (headerSelectedCompetitionAdminAttr == null) {
+        headerSelectedCompetitionAdminAttr = session.getAttribute("selectedCompetitionAdmin");
+    }
     boolean headerSelectedCompetitionAdmin = headerSelectedCompetitionAdminAttr instanceof Boolean && (Boolean) headerSelectedCompetitionAdminAttr;
     Object headerCompetitionSetupAllowedAttr = request.getAttribute("competitionSetupAllowed");
+    if (headerCompetitionSetupAllowedAttr == null) {
+        headerCompetitionSetupAllowedAttr = session.getAttribute("competitionSetupAllowed");
+    }
     boolean headerCompetitionSetupAllowed = headerCompetitionSetupAllowedAttr instanceof Boolean && (Boolean) headerCompetitionSetupAllowedAttr;
     Set<Long> headerActiveCompetitionIds = headerActiveCompetitions.stream().map(CompetitionSummaryView::getId).collect(java.util.stream.Collectors.toSet());
+    Object headerAuthUserAttr = request.getAttribute("authUser");
+    if (!(headerAuthUserAttr instanceof AuthenticatedUser)) {
+        headerAuthUserAttr = session.getAttribute("authUser");
+    }
+    AuthenticatedUser headerAuthUser = headerAuthUserAttr instanceof AuthenticatedUser ? (AuthenticatedUser) headerAuthUserAttr : null;
+    Object headerAthleteAttr = request.getAttribute("athlete");
+    if (!(headerAthleteAttr instanceof BootcampAthlete)) {
+        headerAthleteAttr = session.getAttribute("athlete");
+    }
+    BootcampAthlete headerAthlete = headerAthleteAttr instanceof BootcampAthlete ? (BootcampAthlete) headerAthleteAttr : null;
+    String headerProfileName = headerAthlete != null && headerAthlete.getFirstname() != null && !headerAthlete.getFirstname().isBlank()
+            ? (headerAthlete.getFirstname() + (headerAthlete.getLastname() == null || headerAthlete.getLastname().isBlank() ? "" : " " + headerAthlete.getLastname())).trim()
+            : headerAuthUser != null && headerAuthUser.getDisplayName() != null && !headerAuthUser.getDisplayName().isBlank()
+            ? headerAuthUser.getDisplayName()
+            : "Profile";
+    String headerProfileAthleteId = headerAthlete != null ? headerAthlete.getId() : "";
+    String headerProfileMedium = headerAthlete != null ? headerAthlete.getProfileMedium() : "";
+    boolean headerHasProfile = headerAthlete != null && headerAthlete.getId() != null && !headerAthlete.getId().isBlank();
 %>
 <style>
     .user-avatar {
@@ -36,6 +71,37 @@
         align-items: center;
         justify-content: center;
         background: rgba(255, 255, 255, 0.18);
+    }
+
+    .profile-menu-toggle {
+        min-height: 40px;
+    }
+
+    .profile-menu-label {
+        display: inline-block;
+    }
+
+    .profile-menu-toggle .user-avatar,
+    .profile-menu-toggle .user-avatar-placeholder {
+        width: 30px;
+        height: 30px;
+    }
+
+    .profile-menu-toggle .user-avatar-placeholder {
+        font-size: 0.85rem;
+    }
+
+    @media (hover: hover) and (pointer: fine) {
+        .profile-menu:hover .dropdown-menu {
+            display: block;
+            margin-top: 0;
+        }
+    }
+
+    @media (max-width: 575.98px) {
+        .profile-menu-label {
+            display: none;
+        }
     }
 </style>
 
@@ -66,41 +132,14 @@
                         Signed in as <strong id="signedInName"></strong>
                     </div>
                     <div class="btn-group-vertical w-100">
-
-                        <a id="homeBtn" class="btn btn-outline-secondary mb-2 oc-dismiss-nav"
-                           href="<%=ctx%>/">
-                            <i class="bi bi-house-door me-1"></i> Home
-                        </a>
-
                         <a id="loginBtn" class="btn btn-outline-secondary mb-2"
                            href="<%=ctx%>/login">
                             <i class="bi bi-box-arrow-in-right me-1"></i> Login
                         </a>
 
-                        <a id="logoutBtn" class="btn btn-outline-secondary mb-2 d-none"
-                           href="<%=ctx%>/logout">
-                            <i class="bi bi-box-arrow-right me-1"></i> Logout
-                        </a>
-
-                        <a id="switchUserBtn" class="btn btn-outline-secondary mb-2 d-none"
-                           href="<%=ctx%>/switch-user">
-                            <i class="bi bi-arrow-repeat me-1"></i> Switch user
-                        </a>
-
-                        <a class="btn btn-outline-dark mb-2" href="<%=ctx%>/scoring">
-                            <i class="bi bi-star me-1"></i> Scoring
-                        </a>
-
-                        <a class="btn btn-outline-dark mb-2" href="<%=ctx%>/terms.jsp">
-                            <i class="bi bi-exclamation-triangle me-1"></i> Terms of Service
-                        </a>
-
-                        <a class="btn btn-outline-dark mb-2" href="<%=ctx%>/privacy.jsp">
-                            <i class="bi bi-shield-lock me-1"></i> Privacy Policy
-                        </a>
-
-                        <% if (inApp && !headerActiveCompetitions.isEmpty()) { %>
-                        <div class="dropdown mt-3 mb-2">
+                        <div class="text-uppercase small text-muted mt-3 mb-2">Competition</div>
+                        <% if (headerAuthUser != null && !headerActiveCompetitions.isEmpty()) { %>
+                        <div class="dropdown mb-2">
                             <button class="btn btn-outline-primary dropdown-toggle w-100 text-start" type="button" data-bs-toggle="dropdown" aria-expanded="false">
                                 <i class="bi bi-flag me-1"></i> Current competitions (<%= headerActiveCompetitions.size() %>)
                             </button>
@@ -116,7 +155,7 @@
                             </ul>
                         </div>
                         <% } %>
-                        <% if (inApp && !headerPastCompetitions.isEmpty()) { %>
+                        <% if (headerAuthUser != null && !headerPastCompetitions.isEmpty()) { %>
                         <div class="dropdown mb-2">
                             <button class="btn btn-outline-secondary dropdown-toggle w-100 text-start" type="button" data-bs-toggle="dropdown" aria-expanded="false">
                                 <i class="bi bi-clock-history me-1"></i> Past competitions (<%= headerPastCompetitions.size() %>)
@@ -133,7 +172,7 @@
                             </ul>
                         </div>
                         <% } %>
-                        <% if (inApp && Boolean.TRUE.equals(headerCompetitionSetupAllowed)) { %>
+                        <% if (headerAuthUser != null && Boolean.TRUE.equals(headerCompetitionSetupAllowed)) { %>
                         <a class="btn btn-outline-primary mb-2" href="<%=ctx%>/app/competitions">
                             <i class="bi bi-list-check me-1"></i> Manage competitions
                         </a>
@@ -141,16 +180,30 @@
                             <i class="bi bi-plus-circle me-1"></i> Create or join competition
                         </a>
                         <% } %>
-                        <% if (inApp && !headerPendingCompetitionInvitations.isEmpty()) { %>
+                        <% if (headerAuthUser != null && !headerPendingCompetitionInvitations.isEmpty()) { %>
                         <a class="btn btn-warning mb-2" href="<%=ctx%>/app/invitations">
                             <i class="bi bi-envelope-paper me-1"></i> Invitations (<%= headerPendingCompetitionInvitations.size() %>)
                         </a>
                         <% } %>
-                        <% if (inApp && headerSelectedCompetitionAdmin && headerSelectedCompetitionId != null && headerActiveCompetitionIds.contains(headerSelectedCompetitionId)) { %>
-                        <a class="btn btn-outline-warning mb-2" href="<%=ctx%>/app/competition-invitations?competitionId=<%= headerSelectedCompetitionId %>">
-                            <i class="bi bi-person-plus me-1"></i> Manage invites
+                        <% if (headerAuthUser != null) { %>
+                        <a class="btn btn-outline-dark mb-2" href="<%=ctx%>/app/AthleteSummary">
+                            <i class="bi bi-list-ol me-1"></i> Summary
                         </a>
                         <% } %>
+                        <div class="text-uppercase small text-muted mt-3 mb-2">Site</div>
+                        <a id="homeBtn" class="btn btn-outline-secondary mb-2 oc-dismiss-nav"
+                           href="<%=ctx%>/">
+                            <i class="bi bi-house-door me-1"></i> Home
+                        </a>
+                        <a class="btn btn-outline-dark mb-2" href="<%=ctx%>/scoring">
+                            <i class="bi bi-star me-1"></i> Scoring
+                        </a>
+                        <a class="btn btn-outline-dark mb-2" href="<%=ctx%>/terms.jsp">
+                            <i class="bi bi-exclamation-triangle me-1"></i> Terms of Service
+                        </a>
+                        <a class="btn btn-outline-dark mb-2" href="<%=ctx%>/privacy.jsp">
+                            <i class="bi bi-shield-lock me-1"></i> Privacy Policy
+                        </a>
 
                         <button id="linkStravaBtn" class="btn btn-outline-primary d-none" onclick="linkStravaPopup()">
                             <i class="bi bi-link-45deg me-1"></i> Link Strava
@@ -168,15 +221,52 @@
             <span class="brand-text">Frankies Bootcamp!</span>
         </a>
     </h1>
-    <!-- Signed-in user chip -->
-    <span id="userChip" class="user-chip d-none ms-2">
-        <span id="userAvatarWrap" class="me-1 d-none" aria-hidden="true">
-            <img id="userAvatarImg" class="user-avatar" alt="">
-            <span id="userAvatarPlaceholder" class="user-avatar-placeholder d-none"><i class="bi bi-person"></i></span>
-        </span>
-        <span id="userName"></span>
-    </span>
+    <div class="dropdown ms-auto <%= headerHasProfile ? "" : "d-none" %> profile-menu">
+        <button id="profileMenuButton" class="btn btn-sm btn-outline-light dropdown-toggle d-inline-flex align-items-center gap-2 profile-menu-toggle"
+                type="button" data-bs-toggle="dropdown" aria-expanded="false">
+            <span id="profileMenuAvatarWrap" class="d-inline-flex align-items-center justify-content-center" aria-hidden="true">
+                <img id="profileMenuAvatarImg" class="user-avatar <%= headerProfileMedium == null || headerProfileMedium.isBlank() ? "d-none" : "" %>" src="<%=headerProfileMedium == null ? "" : headerProfileMedium%>" alt="">
+                <span id="profileMenuAvatarPlaceholder" class="user-avatar-placeholder <%= headerProfileMedium != null && !headerProfileMedium.isBlank() ? "d-none" : "" %>"><i class="bi bi-person"></i></span>
+            </span>
+            <span id="profileMenuName" class="profile-menu-label text-truncate" style="max-width: 12rem;"><%= headerProfileName %></span>
+        </button>
+        <ul class="dropdown-menu dropdown-menu-end shadow" aria-labelledby="profileMenuButton">
+            <li><h6 class="dropdown-header">Logged in as <span id="profileMenuNameInMenu"><%= headerProfileName %></span></h6></li>
+            <li>
+                <button id="profileMenuViewProfileBtn" class="dropdown-item <%= headerHasProfile ? "" : "d-none" %>" type="button">
+                    <i class="bi bi-person-badge me-2"></i>View profile
+                </button>
+            </li>
+            <li>
+                <a id="profileMenuSwitchUserBtn" class="dropdown-item d-none" href="<%=ctx%>/switch-user">
+                    <i class="bi bi-arrow-repeat me-2"></i>Switch user
+                </a>
+            </li>
+            <li>
+                <a id="profileMenuLogoutBtn" class="dropdown-item d-none" href="<%=ctx%>/logout">
+                    <i class="bi bi-box-arrow-right me-2"></i>Logout
+                </a>
+            </li>
+        </ul>
+    </div>
 </header>
+
+<div class="modal fade" id="athleteProfileModal" tabindex="-1" aria-labelledby="athleteProfileModalTitle" aria-hidden="true">
+    <div class="modal-dialog modal-lg modal-dialog-scrollable">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="athleteProfileModalTitle">Athlete profile</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body" id="athleteProfileModalBody">
+                <div class="d-flex align-items-center gap-2 text-muted">
+                    <div class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></div>
+                    <span>Loading profile...</span>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
 
 <!-- 🔧 tiny safety net if any theme overrides the color -->
 <style>
@@ -193,7 +283,15 @@
 <script>
     (function () {
         const ctx = '<%=ctx%>';
-        const state = { authed: false, name: '', email: '', stravaLinked: false, profileMedium: '' };
+        const inApp = <%= inApp ? "true" : "false" %>;
+        const state = {
+            authed: <%= headerHasProfile ? "true" : "false" %>,
+            name: '<%= headerProfileName.replace("\\", "\\\\").replace("'", "\\'") %>',
+            email: '',
+            stravaLinked: false,
+            profileMedium: '<%= headerProfileMedium == null ? "" : headerProfileMedium.replace("\\", "\\\\").replace("'", "\\'") %>',
+            athleteId: '<%= headerProfileAthleteId == null ? "" : headerProfileAthleteId.replace("\\", "\\\\").replace("'", "\\'") %>'
+        };
 
         async function fetchAuth() {
             try {
@@ -201,7 +299,8 @@
                 const r = await fetch(ctx + '/app/whoami.jsp?ts=' + Date.now(), {
                     credentials: 'include',
                     cache: 'no-store',
-                    redirect: 'manual'
+                    redirect: 'manual',
+                    loadingOverlay: false
                 });
 
                 // if auth bounced us to any login endpoint, treat as logged-out without re-triggering auth
@@ -227,65 +326,200 @@
             render();
         }
 
-        function setLoggedOut() { state.authed = false; state.name = ''; state.email = ''; state.stravaLinked = false; state.profileMedium = ''; }
+        function setLoggedOut() { state.authed = false; state.name = ''; state.email = ''; state.stravaLinked = false; state.profileMedium = ''; state.athleteId = ''; }
 
         function render() {
             const group = document.querySelector('#offcanvasMenu .btn-group-vertical');
             const homeBtn       = document.getElementById('homeBtn');
             const loginBtn      = document.getElementById('loginBtn');
-            const logoutBtn     = document.getElementById('logoutBtn');
-            const switchUserBtn = document.getElementById('switchUserBtn');
-            const linkBtn   = document.getElementById('linkStravaBtn');   // <--
+            const logoutBtn     = document.getElementById('profileMenuLogoutBtn');
+            const switchUserBtn = document.getElementById('profileMenuSwitchUserBtn');
+            const viewProfileBtn = document.getElementById('profileMenuViewProfileBtn');
+            const profileMenu = document.querySelector('.profile-menu');
+            const profileMenuName = document.getElementById('profileMenuName');
+            const profileMenuNameInMenu = document.getElementById('profileMenuNameInMenu');
+            const profileMenuAvatarImg = document.getElementById('profileMenuAvatarImg');
+            const profileMenuAvatarPlaceholder = document.getElementById('profileMenuAvatarPlaceholder');
+            const profileMenuButton = document.getElementById('profileMenuButton');
+            const linkBtn   = document.getElementById('linkStravaBtn');
             const signedInAs    = document.getElementById('signedInAs');
             const signedInName  = document.getElementById('signedInName');
-            const userAvatarWrap = document.getElementById('userAvatarWrap');
-            const userAvatarImg = document.getElementById('userAvatarImg');
-            const userAvatarPlaceholder = document.getElementById('userAvatarPlaceholder');
 
             if (state.authed) {
+                profileMenu && profileMenu.classList.remove('d-none');
                 if (signedInAs) {
                     signedInAs.classList.remove('d-none');
                     signedInName && (signedInName.textContent = state.name || state.email || 'You');
                 }
-                if (userAvatarWrap) {
-                    userAvatarWrap.classList.remove('d-none');
+                if (profileMenuName) {
+                    profileMenuName.textContent = state.name || state.email || 'Profile';
+                }
+                if (profileMenuNameInMenu) {
+                    profileMenuNameInMenu.textContent = state.name || state.email || 'You';
+                }
+                if (profileMenuAvatarImg && profileMenuAvatarPlaceholder) {
                     if (state.profileMedium) {
-                        if (userAvatarImg) {
-                            userAvatarImg.src = state.profileMedium;
-                            userAvatarImg.classList.remove('d-none');
-                        }
-                        userAvatarPlaceholder && userAvatarPlaceholder.classList.add('d-none');
+                        profileMenuAvatarImg.src = state.profileMedium;
+                        profileMenuAvatarImg.classList.remove('d-none');
+                        profileMenuAvatarPlaceholder.classList.add('d-none');
                     } else {
-                        userAvatarImg && userAvatarImg.classList.add('d-none');
-                        userAvatarPlaceholder && userAvatarPlaceholder.classList.remove('d-none');
+                        profileMenuAvatarImg.classList.add('d-none');
+                        profileMenuAvatarPlaceholder.classList.remove('d-none');
                     }
                 }
                 if (loginBtn) {
-                    loginBtn.innerHTML = '<i class="bi bi-speedometer2 me-1"></i> Go to dashboard';
-                    loginBtn.href = ctx + '/app/';
-                    if (group && group.firstElementChild !== loginBtn) {
-                        group.insertBefore(loginBtn, group.firstElementChild);
+                    if (inApp) {
+                        loginBtn.classList.add('d-none');
+                    } else {
+                        loginBtn.classList.remove('d-none');
+                        loginBtn.innerHTML = '<i class="bi bi-speedometer2 me-1"></i> Go to dashboard';
+                        loginBtn.href = ctx + '/app/';
                     }
                 }
                 logoutBtn && logoutBtn.classList.remove('d-none');
                 switchUserBtn && switchUserBtn.classList.remove('d-none');
+                if (viewProfileBtn) {
+                    viewProfileBtn.classList.toggle('d-none', !state.athleteId);
+                }
+                if (viewProfileBtn) {
+                    viewProfileBtn.onclick = function () {
+                        if (state.athleteId) {
+                            openAthleteProfileModal(state.athleteId, state.name || state.email || 'Profile');
+                        }
+                    };
+                }
                 if (linkBtn) {
                     linkBtn.classList.toggle('d-none', state.stravaLinked);
                 }
             } else {
                 if (signedInAs) signedInAs.classList.add('d-none');
-                if (userAvatarWrap) userAvatarWrap.classList.add('d-none');
+                profileMenu && profileMenu.classList.add('d-none');
                 if (loginBtn) {
-                    loginBtn.innerHTML = '<i class="bi bi-box-arrow-in-right me-1"></i> Login';
-                    loginBtn.href = ctx + '/login';
+                    loginBtn.classList.remove('d-none');
+                    if (inApp) {
+                        loginBtn.innerHTML = '<i class="bi bi-speedometer2 me-1"></i> Go to dashboard';
+                        loginBtn.href = ctx + '/app/';
+                    } else {
+                        loginBtn.innerHTML = '<i class="bi bi-box-arrow-in-right me-1"></i> Login';
+                        loginBtn.href = ctx + '/login';
+                    }
                     if (group && homeBtn && homeBtn.nextElementSibling !== loginBtn) {
                         group.insertBefore(loginBtn, homeBtn.nextElementSibling);
                     }
                 }
                 logoutBtn && logoutBtn.classList.add('d-none');
                 switchUserBtn && switchUserBtn.classList.add('d-none');
+                viewProfileBtn && viewProfileBtn.classList.add('d-none');
                 linkBtn && linkBtn.classList.add('d-none');
             }
+        }
+
+        function openAthleteProfileModal(athleteId, athleteName) {
+            if (!athleteId) {
+                return;
+            }
+            const modalElement = document.getElementById('athleteProfileModal');
+            const modalTitle = document.getElementById('athleteProfileModalTitle');
+            const modalBody = document.getElementById('athleteProfileModalBody');
+            if (!modalElement || !modalTitle || !modalBody) {
+                return;
+            }
+            modalTitle.textContent = (athleteName || 'Athlete') + ' profile';
+            modalBody.innerHTML = '<div class="d-flex align-items-center gap-2 text-muted"><div class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></div><span>Loading profile...</span></div>';
+            bootstrap.Modal.getOrCreateInstance(modalElement).show();
+
+            fetch(ctx + '/app/Insights?fragment=profile&athleteId=' + encodeURIComponent(athleteId) + '&ts=' + Date.now(), {
+                credentials: 'include',
+                cache: 'no-store'
+            })
+                .then(function (response) {
+                    if (!response.ok) {
+                        throw new Error('Profile fragment failed');
+                    }
+                    return response.text();
+                })
+                .then(function (html) {
+                    modalBody.innerHTML = html;
+                    bindProfileForms(modalBody);
+                    loadGeneratedBlurbs(modalBody);
+                })
+                .catch(function () {
+                    modalBody.innerHTML = '<div class="alert alert-danger mb-0">Could not load that profile right now.</div>';
+                });
+        }
+
+        function bindProfileForms(root) {
+            (root || document).querySelectorAll('form[data-profile-form]').forEach(function (form) {
+                if (form.dataset.bound === 'true') {
+                    return;
+                }
+                form.dataset.bound = 'true';
+                var textarea = form.querySelector('textarea[name="summaryText"]');
+                if (textarea && form.dataset.initial === undefined) {
+                    form.dataset.initial = textarea.value;
+                }
+                if (textarea) {
+                    textarea.addEventListener('input', function () {
+                        updateProfileButton(form);
+                    });
+                }
+                updateProfileButton(form);
+            });
+        }
+
+        function updateProfileButton(form) {
+            var textarea = form.querySelector('textarea[name="summaryText"]');
+            var submit = form.querySelector('button[type="submit"]');
+            if (!textarea || !submit) {
+                return;
+            }
+            submit.disabled = textarea.disabled || textarea.value === (form.dataset.initial || '');
+        }
+
+        function loadGeneratedBlurbs(root) {
+            (root || document).querySelectorAll('.ai-profile-blurb[data-ai-blurb-athlete-id]').forEach(function (card) {
+                if (card.dataset.aiLoaded === 'true') {
+                    return;
+                }
+                if (card.closest('.athlete-profile-modal-body.d-none')) {
+                    return;
+                }
+                card.dataset.aiLoaded = 'true';
+                var url = card.getAttribute('data-ai-blurb-url');
+                var textTarget = card.querySelector('[data-ai-blurb-text]');
+                var textarea = card.querySelector('textarea[name="summaryText"]');
+                var submit = card.querySelector('button[type="submit"]');
+                var request = new XMLHttpRequest();
+                request.open('GET', url, true);
+                request.onreadystatechange = function () {
+                    if (request.readyState !== 4) {
+                        return;
+                    }
+                    var text = 'Could not generate a profile summary right now.';
+                    if (request.status >= 200 && request.status < 300) {
+                        try {
+                            text = JSON.parse(request.responseText).text || text;
+                        } catch (e) {
+                        }
+                    }
+                    if (textTarget) {
+                        textTarget.textContent = text;
+                    }
+                    if (textarea) {
+                        textarea.value = text;
+                        textarea.disabled = false;
+                        var form = textarea.closest('form[data-profile-form]');
+                        if (form) {
+                            form.dataset.initial = '';
+                            updateProfileButton(form);
+                        }
+                    }
+                    if (submit && !textarea) {
+                        submit.disabled = false;
+                    }
+                };
+                request.send();
+            });
         }
 
         // Run on page load…
@@ -293,6 +527,15 @@
         // …and every time the drawer opens (fixes the “open-before-fetch” case)
         const oc = document.getElementById('offcanvasMenu');
         if (oc) oc.addEventListener('show.bs.offcanvas', fetchAuth);
+        document.addEventListener('click', function (event) {
+            var trigger = event.target.closest('[data-athlete-profile-id]');
+            if (!trigger) {
+                return;
+            }
+            event.preventDefault();
+            openAthleteProfileModal(trigger.getAttribute('data-athlete-profile-id'), trigger.getAttribute('data-athlete-profile-name') || 'Athlete');
+        });
+        window.openAthleteProfileModal = openAthleteProfileModal;
 
     })();
 

--- a/src/main/webapp/WEB-INF/jspf/privacy-content.jspf
+++ b/src/main/webapp/WEB-INF/jspf/privacy-content.jspf
@@ -65,7 +65,7 @@
             <p>We may update this policy as the program evolves. We&rsquo;ll post the new date above and, when material, provide a heads-up.</p>
 
             <p class="section-title">11. Contact</p>
-            <p>Questions or deletion requests? Email <a href="mailto:frankiesbootcamp@gmail.com">frankiesbootcamp@gmail.com</a>.</p>
+            <p>Questions or deletion requests? Email <a href="mailto:support@mail.frankiesbootamp.com">support@mail.frankiesbootamp.com</a>.</p>
 
             <p class="mt-4">See also our <a href="<%=request.getContextPath()%>/terms">Terms of Service</a>.</p>
         </div>

--- a/src/main/webapp/WEB-INF/jspf/terms-content.jspf
+++ b/src/main/webapp/WEB-INF/jspf/terms-content.jspf
@@ -41,7 +41,7 @@
             <p>The Challenge is provided &ldquo;as is&rdquo; without warranties of any kind. To the fullest extent permitted by law, we are not liable for indirect or incidental damages. You&rsquo;re responsible for your participation decisions.</p>
 
             <p class="section-title">12. Contact</p>
-            <p>Questions? <a href="mailto:frankiesbootcamp@gmail.com">frankiesbootcamp@gmail.com</a></p>
+            <p>Questions? <a href="mailto:support@mail.frankiesbootamp.com">support@mail.frankiesbootamp.com</a></p>
 
             <p class="mt-4">See also our <a href="<%=request.getContextPath()%>/privacy">Privacy Policy</a>.</p>
         </div>

--- a/src/main/webapp/app/athlete-summary.jsp
+++ b/src/main/webapp/app/athlete-summary.jsp
@@ -1,0 +1,70 @@
+<%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%@ page import="com.frankies.bootcamp.model.CompetitionSummaryView" %>
+<%@ page import="com.frankies.bootcamp.utils.WildflyUtils" %>
+<%@ page import="java.util.List" %>
+<%
+    String summaryContent = (String) request.getAttribute("summaryContent");
+    Long selectedCompetitionId = (Long) request.getAttribute("selectedCompetitionId");
+    Object activeCompetitionsAttr = request.getAttribute("activeCompetitions");
+    Object pastCompetitionsAttr = request.getAttribute("pastCompetitions");
+    List<CompetitionSummaryView> activeCompetitions = activeCompetitionsAttr instanceof List<?> ? (List<CompetitionSummaryView>) activeCompetitionsAttr : List.of();
+    List<CompetitionSummaryView> pastCompetitions = pastCompetitionsAttr instanceof List<?> ? (List<CompetitionSummaryView>) pastCompetitionsAttr : List.of();
+%>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <%@ include file="/WEB-INF/jspf/head-common.jspf" %>
+    <title>Summary - Frankies Bootcamp</title>
+</head>
+<body>
+<%@ include file="/WEB-INF/jspf/header.jspf" %>
+
+<main class="container my-4">
+    <div class="card shadow-sm border-0 mb-3">
+        <div class="card-body py-3">
+            <form class="row g-2 align-items-end" method="get" action="<%=request.getContextPath()%>/app/select-competition">
+                <input type="hidden" name="returnTo" value="/app/AthleteSummary">
+                <div class="col-md-9">
+                    <label class="form-label mb-1" for="competitionId">Switch competition</label>
+                    <select class="form-select" id="competitionId" name="competitionId">
+                        <% if (!activeCompetitions.isEmpty()) { %>
+                        <optgroup label="Current competitions">
+                            <% for (CompetitionSummaryView competition : activeCompetitions) { %>
+                            <option value="<%= competition.getId() %>" <%= selectedCompetitionId != null && selectedCompetitionId == competition.getId() ? "selected" : "" %>><%= WildflyUtils.escape(competition.getName()) %></option>
+                            <% } %>
+                        </optgroup>
+                        <% } %>
+                        <% if (!pastCompetitions.isEmpty()) { %>
+                        <optgroup label="Past competitions">
+                            <% for (CompetitionSummaryView competition : pastCompetitions) { %>
+                            <option value="<%= competition.getId() %>" <%= selectedCompetitionId != null && selectedCompetitionId == competition.getId() ? "selected" : "" %>><%= WildflyUtils.escape(competition.getName()) %></option>
+                            <% } %>
+                        </optgroup>
+                        <% } %>
+                    </select>
+                </div>
+                <div class="col-md-3 d-grid">
+                    <button class="btn btn-outline-primary" type="submit">Open</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <div class="card shadow-sm border-0">
+        <div class="card-body p-4">
+            <h1 class="h4 mb-3"><i class="bi bi-trophy-fill me-2"></i>Performance Summary</h1>
+            <div class="mt-2">
+                <%= WildflyUtils.escape(summaryContent == null ? "" : summaryContent) %>
+            </div>
+            <hr/>
+            <p class="text-muted mb-0"><i class="bi bi-award-fill text-warning me-2"></i>Keep training hard and breaking limits!</p>
+        </div>
+    </div>
+</main>
+
+<%@ include file="/WEB-INF/jspf/footer.jspf" %>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/src/main/webapp/app/competition-history-only.jsp
+++ b/src/main/webapp/app/competition-history-only.jsp
@@ -10,6 +10,7 @@
     AuthenticatedUser onboardingUser = (AuthenticatedUser) session.getAttribute("authUser");
     OnboardingStatus onboardingStatus = (OnboardingStatus) request.getAttribute("onboardingStatus");
     List<CompetitionSummaryView> pastCompetitions = onboardingStatus == null ? List.of() : onboardingStatus.getPastCompetitions();
+    Boolean competitionSetupAllowed = (Boolean) request.getAttribute("competitionSetupAllowed");
     String displayName = (onboardingUser == null || onboardingUser.getDisplayName() == null || onboardingUser.getDisplayName().isBlank())
             ? "there"
             : onboardingUser.getDisplayName();
@@ -64,7 +65,9 @@
 
                     <div class="d-grid gap-2 d-sm-flex justify-content-sm-center mt-4">
                         <a class="btn btn-outline-secondary btn-lg" href="<%=pageContextPath%>/logout">Sign out</a>
+                        <% if (Boolean.TRUE.equals(competitionSetupAllowed)) { %>
                         <a class="btn btn-primary btn-lg" href="<%=pageContextPath%>/app/competition-setup">Set up or join competition</a>
+                        <% } %>
                     </div>
                 </div>
             </div>

--- a/src/main/webapp/app/competition-invitations.jsp
+++ b/src/main/webapp/app/competition-invitations.jsp
@@ -62,6 +62,27 @@
         }
         return builder.toString();
     }
+
+    private String formatInvitedName(CompetitionInvitationView invitation) {
+        if (invitation == null) {
+            return "";
+        }
+        String firstName = invitation.getInvitedFirstname() == null ? "" : invitation.getInvitedFirstname().trim();
+        String lastName = invitation.getInvitedLastname() == null ? "" : invitation.getInvitedLastname().trim();
+        String fullName = (firstName + " " + lastName).trim();
+        if (!fullName.isBlank()) {
+            return fullName;
+        }
+        String displayName = invitation.getInvitedDisplayName() == null ? "" : invitation.getInvitedDisplayName().trim();
+        if (!displayName.isBlank()) {
+            return displayName;
+        }
+        return "Invited user";
+    }
+
+    private String iconOnlyRewriteButtonClass() {
+        return "btn btn-light btn-sm border shadow-sm position-absolute bottom-0 end-0 me-2 mb-2 rounded-circle d-inline-flex align-items-center justify-content-center invite-rewrite-button";
+    }
 %>
 <!DOCTYPE html>
 <html lang="en">
@@ -70,6 +91,27 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <%@ include file="/WEB-INF/jspf/head-common.jspf" %>
     <title>Manage invitations</title>
+    <style>
+        .invite-message-wrap {
+            position: relative;
+        }
+
+        .invite-message-wrap .form-control {
+            padding-right: 3rem;
+            padding-bottom: 3rem;
+        }
+
+        .invite-rewrite-button {
+            width: 2rem;
+            height: 2rem;
+            padding: 0;
+            opacity: 0.75;
+        }
+
+        .invite-rewrite-button:hover {
+            opacity: 1;
+        }
+    </style>
 </head>
 <body class="bg-light">
 <%@ include file="/WEB-INF/jspf/header.jspf" %>
@@ -91,12 +133,20 @@
                         <input type="hidden" name="action" value="bulkInvite">
                         <input type="hidden" name="competitionId" value="<%= view == null ? "" : view.getCompetitionId() %>">
                         <div class="mb-3">
-                            <label class="form-label" for="emails">Invite by email</label>
+                            <div class="d-flex align-items-center justify-content-between gap-2 flex-wrap mb-1">
+                                <label class="form-label mb-0" for="emails">Invite by email</label>
+                            </div>
                             <textarea class="form-control" id="emails" name="emails" rows="4" placeholder="comma, newline, or semicolon separated emails"></textarea>
                         </div>
                         <div class="mb-3">
-                            <label class="form-label" for="message">Invite message</label>
-                            <textarea class="form-control" id="message" name="message" rows="4" placeholder="Add a friendly note for the invite email"><%= inviteMessage == null ? "" : escapeHtml(inviteMessage) %></textarea>
+                            <label class="form-label mb-1" for="message">Invite message</label>
+                            <div class="invite-message-wrap">
+                                <textarea class="form-control" id="message" name="message" rows="4" placeholder="Add a friendly note for the invite email"><%= inviteMessage == null ? "" : escapeHtml(inviteMessage) %></textarea>
+                                <button class="<%= iconOnlyRewriteButtonClass() %>" type="button" id="rewriteInviteMessageBtn" aria-label="AI rewrite invite message" title="AI rewrite invite message">
+                                    <i class="bi bi-magic"></i>
+                                </button>
+                            </div>
+                            <div class="form-text">Keep your voice; AI can polish it or draft one from the bootcamp motto.</div>
                         </div>
                         <button class="btn btn-primary" type="submit">Send invitations</button>
                     </form>
@@ -194,7 +244,7 @@
                         <div class="list-group-item">
                             <div class="fw-semibold">
                                 <% if (invitation.getInvitedUserId() != null && !invitation.getInvitedUserId().isBlank()) { %>
-                                Invite linked to existing user
+                                <%= escapeHtml(formatInvitedName(invitation)) %>
                                 <% } else { %>
                                 <%= escapeHtml(invitation.getInvitedEmail()) %>
                                 <% } %>
@@ -209,12 +259,105 @@
         </div>
     </div>
 </div>
+
+<div class="modal fade" id="rewriteInviteMessageModal" tabindex="-1" aria-labelledby="rewriteInviteMessageModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg modal-dialog-scrollable">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="rewriteInviteMessageModalLabel">AI rewrite invite message</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <p class="text-muted small mb-3" id="rewriteInviteMessageHint">Refine what you wrote, or generate a fresh invite from the Frankies Bootcamp motto.</p>
+                <div class="alert alert-info d-none" id="rewriteInviteMessageStatus"></div>
+                <textarea class="form-control mb-3" id="rewriteInviteMessageSuggestion" rows="5"></textarea>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-outline-secondary" id="rewriteInviteMessageRegenerateBtn">Regenerate</button>
+                <button type="button" class="btn btn-primary" id="rewriteInviteMessageUseBtn">Use this text</button>
+            </div>
+        </div>
+    </div>
+</div>
 <script>
     (function () {
+        function initRewriteInviteMessage() {
         const messageField = document.getElementById('message');
-        if (!messageField) {
+        const rewriteButton = document.getElementById('rewriteInviteMessageBtn');
+        const modalElement = document.getElementById('rewriteInviteMessageModal');
+        const modalHint = document.getElementById('rewriteInviteMessageHint');
+        const modalStatus = document.getElementById('rewriteInviteMessageStatus');
+        const suggestionField = document.getElementById('rewriteInviteMessageSuggestion');
+        const useButton = document.getElementById('rewriteInviteMessageUseBtn');
+        const regenerateButton = document.getElementById('rewriteInviteMessageRegenerateBtn');
+        if (!messageField || !rewriteButton || !modalElement || !suggestionField || !useButton || !regenerateButton) {
             return;
         }
+        if (!window.bootstrap || !bootstrap.Modal) {
+            return;
+        }
+        const modal = bootstrap.Modal.getOrCreateInstance(modalElement);
+        let sourceMessage = '';
+
+        function setStatus(text, isError) {
+            if (!modalStatus) {
+                return;
+            }
+            modalStatus.textContent = text || '';
+            modalStatus.classList.toggle('d-none', !text);
+            modalStatus.classList.toggle('alert-danger', !!isError);
+            modalStatus.classList.toggle('alert-info', !isError);
+        }
+
+        function loadRewriteSuggestion() {
+            const params = new URLSearchParams();
+            params.set('action', 'rewriteMessage');
+            params.set('competitionId', '<%= view == null ? "" : view.getCompetitionId() %>');
+            params.set('message', sourceMessage);
+            setStatus('Thinking…', false);
+            suggestionField.value = '';
+            fetch('<%=pageContextPath%>/app/competition-invitations?' + params.toString(), {
+                credentials: 'include',
+                cache: 'no-store',
+                headers: { 'Accept': 'application/json' }
+            })
+                .then(function (response) {
+                    if (!response.ok) {
+                        throw new Error('Could not rewrite invite message right now.');
+                    }
+                    return response.json();
+                })
+                .then(function (data) {
+                    suggestionField.value = data && data.message ? data.message : '';
+                    setStatus(data && data.source === 'generated' ? 'Fresh invite generated from the bootcamp motto.' : 'Invite polished while keeping your message.', false);
+                })
+                .catch(function () {
+                    suggestionField.value = sourceMessage;
+                    setStatus('Could not rewrite the message right now.', true);
+                });
+        }
+
+        rewriteButton.addEventListener('click', function () {
+            sourceMessage = messageField.value || '';
+            if (modalHint) {
+                modalHint.textContent = sourceMessage.trim()
+                    ? 'AI will keep your meaning and voice, then polish the invite.'
+                    : 'AI will draft a fresh invite from the Frankies Bootcamp motto.';
+            }
+            loadRewriteSuggestion();
+            modal.show();
+        });
+
+        regenerateButton.addEventListener('click', function () {
+            loadRewriteSuggestion();
+        });
+
+        useButton.addEventListener('click', function () {
+            messageField.value = suggestionField.value || sourceMessage;
+            messageField.dispatchEvent(new Event('input', { bubbles: true }));
+            modal.hide();
+        });
+
         document.querySelectorAll('form[data-invite-form="candidate"]').forEach(function (form) {
             form.addEventListener('submit', function () {
                 const hiddenMessage = form.querySelector('input[name="message"]');
@@ -223,6 +366,13 @@
                 }
             });
         });
+        }
+
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', initRewriteInviteMessage);
+        } else {
+            initRewriteInviteMessage();
+        }
     })();
 </script>
 </body>

--- a/src/main/webapp/app/competition-invitations.jsp
+++ b/src/main/webapp/app/competition-invitations.jsp
@@ -1,0 +1,201 @@
+<%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%@ page import="com.frankies.bootcamp.model.CompetitionInvitationPageView" %>
+<%@ page import="com.frankies.bootcamp.model.CompetitionInvitationView" %>
+<%@ page import="com.frankies.bootcamp.model.CompetitionInviteCandidateView" %>
+<%@ page import="com.frankies.bootcamp.model.BootcampAthlete" %>
+<%@ page import="java.util.List" %>
+<%
+    CompetitionInvitationPageView view = (CompetitionInvitationPageView) request.getAttribute("invitationAdminView");
+    String feedback = (String) request.getAttribute("invitationAdminFeedback");
+    String error = (String) request.getAttribute("invitationAdminError");
+    String pageContextPath = request.getContextPath();
+%>
+<%!
+    private String escapeHtml(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&#39;");
+    }
+
+    private String maskEmail(String email) {
+        if (email == null || email.isBlank()) {
+            return "";
+        }
+        if (email.length() <= 5) {
+            return email;
+        }
+        int at = email.indexOf('@');
+        if (at <= 0) {
+            return email;
+        }
+        String localPart = email.substring(0, at);
+        String domain = email.substring(at);
+        if (localPart.length() <= 2) {
+            return localPart.substring(0, 1) + "***" + domain;
+        }
+        return localPart.substring(0, 1) + "***" + localPart.substring(localPart.length() - 1) + domain;
+    }
+
+    private String formatLocation(String city, String state, String country) {
+        StringBuilder builder = new StringBuilder();
+        if (city != null && !city.isBlank()) {
+            builder.append(city.trim());
+        }
+        if (state != null && !state.isBlank()) {
+            if (builder.length() > 0) {
+                builder.append(", ");
+            }
+            builder.append(state.trim());
+        }
+        if (country != null && !country.isBlank()) {
+            if (builder.length() > 0) {
+                builder.append(", ");
+            }
+            builder.append(country.trim());
+        }
+        return builder.toString();
+    }
+%>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <%@ include file="/WEB-INF/jspf/head-common.jspf" %>
+    <title>Manage invitations</title>
+</head>
+<body class="bg-light">
+<%@ include file="/WEB-INF/jspf/header.jspf" %>
+
+<div class="container py-4">
+    <div class="row justify-content-center">
+        <div class="col-lg-10">
+            <div class="card shadow-sm border-0 mb-4">
+                <div class="card-body p-4">
+                    <h1 class="h4 mb-3">Manage invitations for <%= escapeHtml(view == null ? "competition" : view.getCompetitionName()) %></h1>
+                    <% if (feedback != null && !feedback.isBlank()) { %>
+                    <div class="alert alert-success" role="alert"><%= escapeHtml(feedback) %></div>
+                    <% } %>
+                    <% if (error != null && !error.isBlank()) { %>
+                    <div class="alert alert-danger" role="alert"><%= escapeHtml(error) %></div>
+                    <% } %>
+
+                    <form method="post" action="<%=pageContextPath%>/app/competition-invitations">
+                        <input type="hidden" name="action" value="bulkInvite">
+                        <input type="hidden" name="competitionId" value="<%= view == null ? "" : view.getCompetitionId() %>">
+                        <div class="mb-3">
+                            <label class="form-label" for="emails">Invite by email</label>
+                            <textarea class="form-control" id="emails" name="emails" rows="4" placeholder="comma, newline, or semicolon separated emails"></textarea>
+                        </div>
+                        <button class="btn btn-primary" type="submit">Send invitations</button>
+                    </form>
+                </div>
+            </div>
+
+            <div class="card shadow-sm border-0 mb-4">
+                <div class="card-body p-4">
+                    <h2 class="h5 mb-3">Search existing users by name</h2>
+                    <form class="mb-3" method="get" action="<%=pageContextPath%>/app/competition-invitations">
+                        <input type="hidden" name="competitionId" value="<%= view == null ? "" : view.getCompetitionId() %>">
+                        <div class="input-group">
+                            <input class="form-control" name="q" value="<%= escapeHtml(view == null || view.getSearchQuery() == null ? "" : view.getSearchQuery()) %>" placeholder="name">
+                            <button class="btn btn-outline-primary" type="submit">Search</button>
+                        </div>
+                    </form>
+
+                    <% if (view != null && view.getCandidates() != null && !view.getCandidates().isEmpty()) { %>
+                    <div class="list-group">
+                        <% for (CompetitionInviteCandidateView candidate : view.getCandidates()) { %>
+                        <div class="list-group-item">
+                            <div class="d-flex justify-content-between align-items-start gap-3 flex-wrap">
+                                <div>
+                                    <div class="d-flex align-items-center gap-2">
+                                        <% if (candidate.getProfileMedium() != null && !candidate.getProfileMedium().isBlank()) { %>
+                                        <img class="user-avatar" src="<%= escapeHtml(candidate.getProfileMedium()) %>" alt="" onerror="this.style.display='none';this.nextElementSibling.classList.remove('d-none');">
+                                        <span class="user-avatar-placeholder d-none"><i class="bi bi-person"></i></span>
+                                        <% } else { %>
+                                        <span class="user-avatar-placeholder"><i class="bi bi-person"></i></span>
+                                        <% } %>
+                                        <div class="fw-semibold"><%= escapeHtml(candidate.getDisplayName()) %></div>
+                                    </div>
+                                    <div class="text-muted small"><%= escapeHtml(maskEmail(candidate.getEmail())) %></div>
+                                    <% String candidateLocation = formatLocation(candidate.getCity(), candidate.getState(), candidate.getCountry()); %>
+                                    <% if (!candidateLocation.isBlank()) { %>
+                                    <div class="text-muted small"><%= escapeHtml(candidateLocation) %></div>
+                                    <% } %>
+                                </div>
+                                <% if (candidate.isAlreadyInCompetition()) { %>
+                                <span class="badge text-bg-secondary">Already active</span>
+                                <% } else { %>
+                                <form method="post" action="<%=pageContextPath%>/app/competition-invitations">
+                                    <input type="hidden" name="action" value="inviteCandidate">
+                                    <input type="hidden" name="competitionId" value="<%= view.getCompetitionId() %>">
+                                    <input type="hidden" name="invitedUserId" value="<%= escapeHtml(candidate.getUserId()) %>">
+                                    <input type="hidden" name="invitedEmail" value="<%= escapeHtml(candidate.getEmail()) %>">
+                                    <button class="btn btn-sm btn-primary" type="submit">Invite</button>
+                                </form>
+                                <% } %>
+                            </div>
+                        </div>
+                        <% } %>
+                    </div>
+                    <% } else { %>
+                    <div class="alert alert-info mb-0">Search for people to invite.</div>
+                    <% } %>
+                </div>
+            </div>
+
+            <div class="card shadow-sm border-0">
+                <div class="card-body p-4">
+                    <h2 class="h5 mb-3">Accepted members</h2>
+                    <% if (view == null || view.getAcceptedAthletes() == null || view.getAcceptedAthletes().isEmpty()) { %>
+                    <div class="alert alert-info mb-4">No one has joined this competition yet.</div>
+                    <% } else { %>
+                    <div class="list-group mb-4">
+                        <% for (BootcampAthlete accepted : view.getAcceptedAthletes()) { %>
+                        <div class="list-group-item">
+                            <div class="d-flex align-items-center gap-2">
+                                <% if (accepted.getProfileMedium() != null && !accepted.getProfileMedium().isBlank()) { %>
+                                <img class="user-avatar" src="<%= escapeHtml(accepted.getProfileMedium()) %>" alt="" onerror="this.style.display='none';this.nextElementSibling.classList.remove('d-none');">
+                                <span class="user-avatar-placeholder d-none"><i class="bi bi-person"></i></span>
+                                <% } else { %>
+                                <span class="user-avatar-placeholder"><i class="bi bi-person"></i></span>
+                                <% } %>
+                                <div class="fw-semibold"><%= escapeHtml((accepted.getFirstname() == null ? "" : accepted.getFirstname()) + " " + (accepted.getLastname() == null ? "" : accepted.getLastname())) %></div>
+                            </div>
+                            <div class="text-muted small"><%= escapeHtml(maskEmail(accepted.getEmail())) %></div>
+                            <% String location = formatLocation(accepted.getCity(), accepted.getState(), accepted.getCountry()); %>
+                            <% if (!location.isBlank()) { %>
+                            <div class="text-muted small"><%= escapeHtml(location) %></div>
+                            <% } %>
+                        </div>
+                        <% } %>
+                    </div>
+                    <% } %>
+
+                    <h2 class="h5 mb-3">Pending invitations</h2>
+                    <% if (view == null || view.getPendingInvitations() == null || view.getPendingInvitations().isEmpty()) { %>
+                    <div class="alert alert-info mb-0">No pending invitations.</div>
+                    <% } else { %>
+                    <div class="list-group">
+                        <% for (CompetitionInvitationView invitation : view.getPendingInvitations()) { %>
+                        <div class="list-group-item">
+                            <div class="fw-semibold"><%= escapeHtml(invitation.getInvitedEmail()) %></div>
+                            <div class="text-muted small">Status: <%= escapeHtml(invitation.getStatus()) %></div>
+                        </div>
+                        <% } %>
+                    </div>
+                    <% } %>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/webapp/app/competition-invitations.jsp
+++ b/src/main/webapp/app/competition-invitations.jsp
@@ -9,6 +9,7 @@
     String feedback = (String) request.getAttribute("invitationAdminFeedback");
     String error = (String) request.getAttribute("invitationAdminError");
     String pageContextPath = request.getContextPath();
+    String inviteMessage = request.getParameter("message");
 %>
 <%!
     private String escapeHtml(String value) {
@@ -93,6 +94,10 @@
                             <label class="form-label" for="emails">Invite by email</label>
                             <textarea class="form-control" id="emails" name="emails" rows="4" placeholder="comma, newline, or semicolon separated emails"></textarea>
                         </div>
+                        <div class="mb-3">
+                            <label class="form-label" for="message">Invite message</label>
+                            <textarea class="form-control" id="message" name="message" rows="4" placeholder="Add a friendly note for the invite email"><%= inviteMessage == null ? "" : escapeHtml(inviteMessage) %></textarea>
+                        </div>
                         <button class="btn btn-primary" type="submit">Send invitations</button>
                     </form>
                 </div>
@@ -133,11 +138,12 @@
                                 <% if (candidate.isAlreadyInCompetition()) { %>
                                 <span class="badge text-bg-secondary">Already active</span>
                                 <% } else { %>
-                                <form method="post" action="<%=pageContextPath%>/app/competition-invitations">
+                                <form method="post" action="<%=pageContextPath%>/app/competition-invitations" data-invite-form="candidate">
                                     <input type="hidden" name="action" value="inviteCandidate">
                                     <input type="hidden" name="competitionId" value="<%= view.getCompetitionId() %>">
                                     <input type="hidden" name="invitedUserId" value="<%= escapeHtml(candidate.getUserId()) %>">
                                     <input type="hidden" name="invitedEmail" value="<%= escapeHtml(candidate.getEmail()) %>">
+                                    <input type="hidden" name="message" value="">
                                     <button class="btn btn-sm btn-primary" type="submit">Invite</button>
                                 </form>
                                 <% } %>
@@ -186,7 +192,13 @@
                     <div class="list-group">
                         <% for (CompetitionInvitationView invitation : view.getPendingInvitations()) { %>
                         <div class="list-group-item">
-                            <div class="fw-semibold"><%= escapeHtml(invitation.getInvitedEmail()) %></div>
+                            <div class="fw-semibold">
+                                <% if (invitation.getInvitedUserId() != null && !invitation.getInvitedUserId().isBlank()) { %>
+                                Invite linked to existing user
+                                <% } else { %>
+                                <%= escapeHtml(invitation.getInvitedEmail()) %>
+                                <% } %>
+                            </div>
                             <div class="text-muted small">Status: <%= escapeHtml(invitation.getStatus()) %></div>
                         </div>
                         <% } %>
@@ -197,5 +209,21 @@
         </div>
     </div>
 </div>
+<script>
+    (function () {
+        const messageField = document.getElementById('message');
+        if (!messageField) {
+            return;
+        }
+        document.querySelectorAll('form[data-invite-form="candidate"]').forEach(function (form) {
+            form.addEventListener('submit', function () {
+                const hiddenMessage = form.querySelector('input[name="message"]');
+                if (hiddenMessage) {
+                    hiddenMessage.value = messageField.value;
+                }
+            });
+        });
+    })();
+</script>
 </body>
 </html>

--- a/src/main/webapp/app/competition-onboarding.jsp
+++ b/src/main/webapp/app/competition-onboarding.jsp
@@ -44,18 +44,18 @@
                     </div>
 
                     <p class="mb-3">
-                        Choose whether to create a competition or join an existing one so your competition membership is explicit.
+                        Your account is ready. Wait for a competition invitation from an admin, or open an invite link if you already have one.
                     </p>
 
                     <ul class="text-muted">
                         <li>Your app user is ready.</li>
                         <li>Your Strava link is complete.</li>
-                        <li>Your next step is to create a competition or join one.</li>
+                        <li>Your next step is to accept a competition invitation.</li>
                     </ul>
 
                     <div class="d-grid gap-2 d-sm-flex justify-content-sm-center mt-4">
                         <a class="btn btn-outline-secondary btn-lg" href="<%=pageContextPath%>/logout">Sign out</a>
-                        <a class="btn btn-primary btn-lg" href="<%=pageContextPath%>/app/competition-setup">Set up or join competition</a>
+                        <a class="btn btn-primary btn-lg" href="<%=pageContextPath%>/app/invitations">View invitations</a>
                     </div>
                 </div>
             </div>

--- a/src/main/webapp/app/competition-selection.jsp
+++ b/src/main/webapp/app/competition-selection.jsp
@@ -47,6 +47,14 @@
                         </p>
                     </div>
 
+                    <div class="d-grid gap-2 d-sm-flex justify-content-sm-center mb-4">
+                        <a class="btn btn-primary" href="<%=pageContextPath%>/app/competition-setup">Create or join competition</a>
+                        <% if (request.getAttribute("selectedCompetitionAdmin") instanceof Boolean selectedAdmin && selectedAdmin
+                                && request.getAttribute("selectedCompetitionId") instanceof Long selectedId) { %>
+                        <a class="btn btn-outline-warning" href="<%=pageContextPath%>/app/competition-invitations?competitionId=<%= selectedId %>">Manage invites for selected competition</a>
+                        <% } %>
+                    </div>
+
                     <h2 class="h5 mt-4">Current competitions</h2>
                     <% if (selectionActiveCompetitions.isEmpty()) { %>
                     <div class="alert alert-info">You do not have any current active competitions.</div>

--- a/src/main/webapp/app/competition-selection.jsp
+++ b/src/main/webapp/app/competition-selection.jsp
@@ -11,6 +11,8 @@
     OnboardingStatus onboardingStatus = (OnboardingStatus) request.getAttribute("onboardingStatus");
     Object selectionActiveCompetitionsAttr = request.getAttribute("activeCompetitions");
     Object selectionPastCompetitionsAttr = request.getAttribute("pastCompetitions");
+    Object selectionAvailableCompetitionsAttr = request.getAttribute("availableCompetitions");
+    Object activeCompetitionAdminIdsAttr = request.getAttribute("activeCompetitionAdminIds");
     Object selectedCompetitionAdminAttr = request.getAttribute("selectedCompetitionAdmin");
     Object selectedCompetitionIdAttr = request.getAttribute("selectedCompetitionId");
     List<CompetitionSummaryView> selectionActiveCompetitions = onboardingStatus == null
@@ -19,8 +21,12 @@
     List<CompetitionSummaryView> selectionPastCompetitions = onboardingStatus == null
             ? (selectionPastCompetitionsAttr instanceof List<?> ? (List<CompetitionSummaryView>) selectionPastCompetitionsAttr : List.of())
             : onboardingStatus.getPastCompetitions();
+    List<CompetitionSummaryView> selectionAvailableCompetitions = selectionAvailableCompetitionsAttr instanceof List<?> ? (List<CompetitionSummaryView>) selectionAvailableCompetitionsAttr : List.of();
+    java.util.Set<Long> activeCompetitionAdminIds = activeCompetitionAdminIdsAttr instanceof java.util.Set<?> ? (java.util.Set<Long>) activeCompetitionAdminIdsAttr : java.util.Set.of();
     boolean selectedCompetitionAdmin = selectedCompetitionAdminAttr instanceof Boolean && (Boolean) selectedCompetitionAdminAttr;
     Long selectedCompetitionId = selectedCompetitionIdAttr instanceof Long ? (Long) selectedCompetitionIdAttr : null;
+    String leaveError = request.getParameter("leaveError");
+    String leaveErrorMessage = "last-admin".equals(leaveError) ? "You are the last admin for this competition." : null;
     String displayName = (onboardingUser == null || onboardingUser.getDisplayName() == null || onboardingUser.getDisplayName().isBlank())
             ? "there"
             : onboardingUser.getDisplayName();
@@ -53,9 +59,6 @@
 
                     <div class="d-grid gap-2 d-sm-flex justify-content-sm-center mb-4">
                         <a class="btn btn-primary" href="<%=pageContextPath%>/app/competition-setup">Create or join competition</a>
-                        <% if (selectedCompetitionAdmin && selectedCompetitionId != null) { %>
-                        <a class="btn btn-outline-warning" href="<%=pageContextPath%>/app/competition-invitations?competitionId=<%= selectedCompetitionId %>">Manage invites for selected competition</a>
-                        <% } %>
                     </div>
 
                     <h2 class="h5 mt-4">Current competitions</h2>
@@ -72,7 +75,41 @@
                                 <div class="fw-semibold"><%= competition.getName() %></div>
                                 <div class="text-muted small">Start: <%= startLabel %> | End: <%= endLabel %></div>
                             </div>
-                            <a class="btn btn-sm btn-outline-primary" href="<%=pageContextPath%>/app/select-competition?competitionId=<%= competition.getId() %>">Open</a>
+                            <div class="d-flex gap-2 flex-wrap">
+                                <a class="btn btn-sm btn-outline-primary" href="<%=pageContextPath%>/app/select-competition?competitionId=<%= competition.getId() %>">Open</a>
+                                <% if (activeCompetitionAdminIds.contains(competition.getId())) { %>
+                                <a class="btn btn-sm btn-outline-warning" href="<%=pageContextPath%>/app/competition-invitations?competitionId=<%= competition.getId() %>">Manage invites</a>
+                                <% } %>
+                                <form method="post" action="<%=pageContextPath%>/app/competitions" class="m-0" onsubmit="return confirm('Leave <%= competition.getName() %>?');" data-loading-submit="true" data-loading-message="Leaving competition...">
+                                    <input type="hidden" name="action" value="leave">
+                                    <input type="hidden" name="competitionId" value="<%= competition.getId() %>">
+                                    <button type="submit" class="btn btn-sm btn-outline-danger">Leave</button>
+                                </form>
+                            </div>
+                        </li>
+                        <% } %>
+                    </ul>
+                    <% } %>
+
+                    <h2 class="h5 mt-4">Available competitions</h2>
+                    <% if (selectionAvailableCompetitions.isEmpty()) { %>
+                    <div class="alert alert-info">No available competitions right now.</div>
+                    <% } else { %>
+                    <ul class="list-group mb-4">
+                        <% for (CompetitionSummaryView competition : selectionAvailableCompetitions) {
+                            String startLabel = Instant.ofEpochSecond(competition.getStartTimestamp()).atZone(ZoneId.of(competition.getTimezone())).format(formatter);
+                            String endLabel = competition.getEndTimestamp() == null ? "No end date" : Instant.ofEpochSecond(competition.getEndTimestamp()).atZone(ZoneId.of(competition.getTimezone())).format(formatter);
+                        %>
+                        <li class="list-group-item d-flex justify-content-between align-items-start">
+                            <div>
+                                <div class="fw-semibold"><%= competition.getName() %></div>
+                                <div class="text-muted small">Start: <%= startLabel %> | End: <%= endLabel %></div>
+                            </div>
+                            <form method="post" action="<%=pageContextPath%>/app/competitions" class="m-0" data-loading-submit="true" data-loading-message="Rejoining competition...">
+                                <input type="hidden" name="action" value="join">
+                                <input type="hidden" name="competitionId" value="<%= competition.getId() %>">
+                                <button type="submit" class="btn btn-sm btn-outline-primary">Rejoin</button>
+                            </form>
                         </li>
                         <% } %>
                     </ul>
@@ -104,5 +141,36 @@
         </div>
     </div>
 </div>
+
+<div class="modal fade" id="competitionLeaveErrorModal" tabindex="-1" aria-labelledby="competitionLeaveErrorModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="competitionLeaveErrorModalLabel">Can't leave competition</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <div class="alert alert-danger mb-0"><%= leaveErrorMessage == null ? "" : leaveErrorMessage %></div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-primary" data-bs-dismiss="modal">OK</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+    (function () {
+        var leaveErrorMessage = <%= leaveErrorMessage == null ? "null" : ("'" + leaveErrorMessage.replace("\\", "\\\\").replace("'", "\\'") + "'") %>;
+        if (!leaveErrorMessage) {
+            return;
+        }
+        var modalElement = document.getElementById('competitionLeaveErrorModal');
+        if (modalElement && window.bootstrap) {
+            bootstrap.Modal.getOrCreateInstance(modalElement).show();
+        }
+    })();
+</script>
+
 </body>
 </html>

--- a/src/main/webapp/app/competition-selection.jsp
+++ b/src/main/webapp/app/competition-selection.jsp
@@ -11,12 +11,16 @@
     OnboardingStatus onboardingStatus = (OnboardingStatus) request.getAttribute("onboardingStatus");
     Object selectionActiveCompetitionsAttr = request.getAttribute("activeCompetitions");
     Object selectionPastCompetitionsAttr = request.getAttribute("pastCompetitions");
+    Object selectedCompetitionAdminAttr = request.getAttribute("selectedCompetitionAdmin");
+    Object selectedCompetitionIdAttr = request.getAttribute("selectedCompetitionId");
     List<CompetitionSummaryView> selectionActiveCompetitions = onboardingStatus == null
             ? (selectionActiveCompetitionsAttr instanceof List<?> ? (List<CompetitionSummaryView>) selectionActiveCompetitionsAttr : List.of())
             : onboardingStatus.getActiveCompetitions();
     List<CompetitionSummaryView> selectionPastCompetitions = onboardingStatus == null
             ? (selectionPastCompetitionsAttr instanceof List<?> ? (List<CompetitionSummaryView>) selectionPastCompetitionsAttr : List.of())
             : onboardingStatus.getPastCompetitions();
+    boolean selectedCompetitionAdmin = selectedCompetitionAdminAttr instanceof Boolean && (Boolean) selectedCompetitionAdminAttr;
+    Long selectedCompetitionId = selectedCompetitionIdAttr instanceof Long ? (Long) selectedCompetitionIdAttr : null;
     String displayName = (onboardingUser == null || onboardingUser.getDisplayName() == null || onboardingUser.getDisplayName().isBlank())
             ? "there"
             : onboardingUser.getDisplayName();
@@ -49,9 +53,8 @@
 
                     <div class="d-grid gap-2 d-sm-flex justify-content-sm-center mb-4">
                         <a class="btn btn-primary" href="<%=pageContextPath%>/app/competition-setup">Create or join competition</a>
-                        <% if (request.getAttribute("selectedCompetitionAdmin") instanceof Boolean selectedAdmin && selectedAdmin
-                                && request.getAttribute("selectedCompetitionId") instanceof Long selectedId) { %>
-                        <a class="btn btn-outline-warning" href="<%=pageContextPath%>/app/competition-invitations?competitionId=<%= selectedId %>">Manage invites for selected competition</a>
+                        <% if (selectedCompetitionAdmin && selectedCompetitionId != null) { %>
+                        <a class="btn btn-outline-warning" href="<%=pageContextPath%>/app/competition-invitations?competitionId=<%= selectedCompetitionId %>">Manage invites for selected competition</a>
                         <% } %>
                     </div>
 

--- a/src/main/webapp/app/competition-setup.jsp
+++ b/src/main/webapp/app/competition-setup.jsp
@@ -5,12 +5,14 @@
 <%@ page import="java.time.Instant" %>
 <%@ page import="java.time.ZoneId" %>
 <%@ page import="java.time.format.DateTimeFormatter" %>
+<%@ page import="java.util.TreeSet" %>
 <%
     CompetitionSetupView setupView = (CompetitionSetupView) request.getAttribute("competitionSetupView");
     List<CompetitionInvitationView> pendingInvitations = (List<CompetitionInvitationView>) request.getAttribute("pendingCompetitionInvitations");
     String pageContextPath = request.getContextPath();
     String error = (String) request.getAttribute("competitionSetupError");
     DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd MMM yyyy");
+    TreeSet<String> availableTimezones = new TreeSet<>(ZoneId.getAvailableZoneIds());
 %>
 <!DOCTYPE html>
 <html lang="en">
@@ -51,7 +53,12 @@
 
                                 <div class="mb-3">
                                     <label class="form-label" for="timezone">Timezone</label>
-                                    <input class="form-control" id="timezone" name="timezone" value="Australia/Sydney" required>
+                                    <select class="form-select" id="timezone" name="timezone" required>
+                                        <% for (String timezone : availableTimezones) { %>
+                                        <option value="<%= timezone %>"><%= timezone %></option>
+                                        <% } %>
+                                    </select>
+                                    <div class="form-text">Your device timezone will be selected automatically.</div>
                                 </div>
 
                                 <div class="mb-3">
@@ -109,5 +116,17 @@
         </div>
     </div>
 </div>
+<script>
+    (function () {
+        const timezoneSelect = document.getElementById('timezone');
+        if (!timezoneSelect || !window.Intl || !Intl.DateTimeFormat) {
+            return;
+        }
+        const detectedTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+        if (detectedTimezone) {
+            timezoneSelect.value = detectedTimezone;
+        }
+    })();
+</script>
 </body>
 </html>

--- a/src/main/webapp/app/competition-setup.jsp
+++ b/src/main/webapp/app/competition-setup.jsp
@@ -74,40 +74,6 @@
                     </div>
                 </div>
 
-                <div class="col-lg-6">
-                    <div class="card h-100 shadow-sm border-0">
-                        <div class="card-body p-4">
-                            <h2 class="h5 mb-3">Join an existing competition</h2>
-                            <form method="post" action="<%=pageContextPath%>/app/competition-setup">
-                                <input type="hidden" name="action" value="join">
-
-                                <div class="mb-3">
-                                    <label class="form-label" for="competitionId">Available competitions</label>
-                                    <select class="form-select" id="competitionId" name="competitionId" required>
-                                        <option value="">Select a competition</option>
-                                        <% if (setupView != null) {
-                                            for (CompetitionSummaryView competition : setupView.getActiveCompetitions()) {
-                                                String startLabel = Instant.ofEpochSecond(competition.getStartTimestamp())
-                                                        .atZone(ZoneId.of(competition.getTimezone()))
-                                                        .format(formatter);
-                                        %>
-                                        <option value="<%= competition.getId() %>"><%= competition.getName() %> - starts <%= startLabel %></option>
-                                        <%  }
-                                           } %>
-                                    </select>
-                                </div>
-
-                                <div class="mb-3">
-                                    <label class="form-label" for="joinStartingGoal">Starting goal</label>
-                                    <input class="form-control" id="joinStartingGoal" name="joinStartingGoal" type="number" min="0" step="0.1"
-                                           value="<%= setupView == null || setupView.getSuggestedStartingGoal() == null ? "20" : setupView.getSuggestedStartingGoal() %>">
-                                </div>
-
-                                <button class="btn btn-outline-primary" type="submit">Join competition</button>
-                            </form>
-                        </div>
-                    </div>
-                </div>
             </div>
         </div>
     </div>

--- a/src/main/webapp/app/competition-setup.jsp
+++ b/src/main/webapp/app/competition-setup.jsp
@@ -1,4 +1,5 @@
 <%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%@ page import="com.frankies.bootcamp.model.CompetitionInvitationView" %>
 <%@ page import="com.frankies.bootcamp.model.CompetitionSetupView" %>
 <%@ page import="com.frankies.bootcamp.model.CompetitionSummaryView" %>
 <%@ page import="java.time.Instant" %>
@@ -6,6 +7,7 @@
 <%@ page import="java.time.format.DateTimeFormatter" %>
 <%
     CompetitionSetupView setupView = (CompetitionSetupView) request.getAttribute("competitionSetupView");
+    List<CompetitionInvitationView> pendingInvitations = (List<CompetitionInvitationView>) request.getAttribute("pendingCompetitionInvitations");
     String pageContextPath = request.getContextPath();
     String error = (String) request.getAttribute("competitionSetupError");
     DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd MMM yyyy");
@@ -68,8 +70,37 @@
                                            value="<%= setupView == null || setupView.getSuggestedStartingGoal() == null ? "20" : setupView.getSuggestedStartingGoal() %>">
                                 </div>
 
-                                <button class="btn btn-primary" type="submit">Create competition</button>
+                                <button class="btn btn-primary" type="submit">Create competition and continue to invites</button>
                             </form>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="col-lg-6">
+                    <div class="card h-100 shadow-sm border-0">
+                        <div class="card-body p-4">
+                            <h2 class="h5 mb-3">Join with an invite</h2>
+                            <% if (pendingInvitations == null || pendingInvitations.isEmpty()) { %>
+                            <div class="alert alert-info mb-0">No pending invitations right now.</div>
+                            <% } else { %>
+                            <div class="list-group">
+                                <% for (CompetitionInvitationView invitation : pendingInvitations) { %>
+                                <div class="list-group-item">
+                                    <div class="fw-semibold"><%= invitation.getCompetitionName() %></div>
+                                    <div class="text-muted small">
+                                        <% if (invitation.getInvitedUserId() != null && !invitation.getInvitedUserId().isBlank()) { %>
+                                        This invite is linked to your account.
+                                        <% } else { %>
+                                        Use the invite from your email to join this competition.
+                                        <% } %>
+                                    </div>
+                                    <div class="d-grid d-sm-flex gap-2 mt-3">
+                                        <a class="btn btn-primary" href="<%=pageContextPath%>/invite?token=<%= invitation.getToken() %>">Use invite</a>
+                                    </div>
+                                </div>
+                                <% } %>
+                            </div>
+                            <% } %>
                         </div>
                     </div>
                 </div>

--- a/src/main/webapp/app/competition-starts-soon.jsp
+++ b/src/main/webapp/app/competition-starts-soon.jsp
@@ -9,6 +9,7 @@
     AuthenticatedUser onboardingUser = (AuthenticatedUser) session.getAttribute("authUser");
     OnboardingStatus onboardingStatus = (OnboardingStatus) request.getAttribute("onboardingStatus");
     CompetitionSummaryView competition = onboardingStatus == null ? null : onboardingStatus.getActiveCompetition();
+    Boolean competitionSetupAllowed = (Boolean) request.getAttribute("competitionSetupAllowed");
     String displayName = (onboardingUser == null || onboardingUser.getDisplayName() == null || onboardingUser.getDisplayName().isBlank())
             ? "there"
             : onboardingUser.getDisplayName();
@@ -52,7 +53,9 @@
 
                     <div class="d-grid gap-2 d-sm-flex justify-content-sm-center mt-4">
                         <a class="btn btn-outline-secondary btn-lg" href="<%=pageContextPath%>/logout">Sign out</a>
+                        <% if (Boolean.TRUE.equals(competitionSetupAllowed)) { %>
                         <a class="btn btn-primary btn-lg" href="<%=pageContextPath%>/app/competition-setup">View competitions</a>
+                        <% } %>
                     </div>
                 </div>
             </div>

--- a/src/main/webapp/app/index.jsp
+++ b/src/main/webapp/app/index.jsp
@@ -11,21 +11,6 @@
     <meta charset="UTF-8">
     <%@ include file="/WEB-INF/jspf/head-common.jspf" %>
     <title>Frankies Bootcamp</title>
-    <script>
-        function openTab(evt, tabName) {
-            var i, tabcontent, tablinks;
-            tabcontent = document.getElementsByClassName("tab-content");
-            for (i = 0; i < tabcontent.length; i++) {
-                tabcontent[i].style.display = "none";
-            }
-            tablinks = document.getElementsByClassName("tab-button");
-            for (i = 0; i < tablinks.length; i++) {
-                tablinks[i].classList.remove("active");
-            }
-            document.getElementById(tabName).style.display = "block";
-            evt.currentTarget.classList.add("active");
-        }
-    </script>
 </head>
 <body>
 <%@ include file="/WEB-INF/jspf/header.jspf" %>
@@ -34,18 +19,18 @@
 <div id="tabsContainer" class="overflow-auto"
      style="position: sticky; top: 56px; z-index: 1020; background-color: white; border-bottom: 1px solid #ddd;">
     <div class="d-flex flex-row flex-nowrap">
-        <button class="tab-button active" onclick="openTab(event, 'Tab1Content', 'history')"><i
+        <button class="tab-button active" data-tab-content="Tab1Content" data-audit-tab="history" onclick="openTab(event, 'Tab1Content', 'history')"><i
                 class="bi bi-hourglass-bottom header-icon"></i>Weekly History
         </button>
-        <button class="tab-button" onclick="openTab(event, 'Tab3Content', 'leaderboard')"><i
+        <button class="tab-button" data-tab-content="Tab3Content" data-audit-tab="leaderboard" onclick="openTab(event, 'Tab3Content', 'leaderboard')"><i
                 class='bi bi-bar-chart-line-fill header-icon'></i>Leaderboard
         </button>
-        <button class="tab-button" onclick="openTab(event, 'Tab2Content', 'honour-roll')"><i class="bi bi-trophy-fill header-icon"></i>Honour
+        <button class="tab-button" data-tab-content="Tab2Content" data-audit-tab="honour-roll" onclick="openTab(event, 'Tab2Content', 'honour-roll')"><i class="bi bi-trophy-fill header-icon"></i>Honour
             Roll
         </button>
-        <button class="tab-button" onclick="openTab(event, 'Tab4Content', 'summary')"><i class="bi bi-list-ol header-icon"></i>Summary
+        <button class="tab-button" data-tab-content="Tab4Content" data-audit-tab="summary" onclick="openTab(event, 'Tab4Content', 'summary')"><i class="bi bi-list-ol header-icon"></i>Summary
         </button>
-        <button class="tab-button" onclick="openTab(event, 'Tab8Content', 'insights')"><i class="bi bi-lightbulb-fill header-icon"></i>Insights
+        <button class="tab-button" data-tab-content="Tab8Content" data-audit-tab="insights" onclick="openTab(event, 'Tab8Content', 'insights')"><i class="bi bi-lightbulb-fill header-icon"></i>Insights
         </button>
     </div>
 </div>
@@ -82,18 +67,6 @@
 <%@ include file="/WEB-INF/jspf/zenbot.jspf" %>
 
 <script>
-    document.getElementsByClassName("tab-button")[0].click(); // Default to first tab
-    fetch('<%=request.getContextPath()%>/app/TabAudit', {
-        method: 'POST',
-        credentials: 'include',
-        cache: 'no-store',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8' },
-        body: 'tab=' + encodeURIComponent('landing')
-    }).catch(function () {
-        // keep landing resilient even if audit logging fails
-    });
-</script>
-<script>
     function openTab(evt, tabName, auditTab) {
         var i, tabcontent, tablinks;
         tabcontent = document.getElementsByClassName("tab-content");
@@ -104,12 +77,18 @@
         for (i = 0; i < tablinks.length; i++) {
             tablinks[i].classList.remove("active");
         }
-        document.getElementById(tabName).style.display = "block";
-        if (evt.currentTarget.classList.contains("tab-button")) {
+        var tabElement = document.getElementById(tabName);
+        if (!tabElement) return;
+        tabElement.style.display = "block";
+        if (evt && evt.currentTarget && evt.currentTarget.classList.contains("tab-button")) {
             evt.currentTarget.classList.add("active");
+        } else {
+            var matchingButton = document.querySelector('.tab-button[data-tab-content="' + tabName + '"]');
+            if (matchingButton) matchingButton.classList.add("active");
         }
 
-        if (auditTab && evt.isTrusted) {
+        if (auditTab && evt && evt.isTrusted) {
+            rememberActiveTab(auditTab);
             fetch('<%=request.getContextPath()%>/app/TabAudit', {
                 method: 'POST',
                 credentials: 'include',
@@ -121,6 +100,41 @@
             });
         }
     }
+
+    function rememberActiveTab(tabName) {
+        if (!window.history || !window.URL) return;
+        var url = new URL(window.location.href);
+        url.searchParams.set('tab', tabName);
+        url.hash = '';
+        window.history.replaceState({}, '', url);
+    }
+
+    function requestedTab() {
+        var url = new URL(window.location.href);
+        var tab = url.searchParams.get('tab');
+        if (!tab && window.location.hash) {
+            tab = window.location.hash.substring(1);
+        }
+        return tab || 'history';
+    }
+
+    function activateRequestedTab() {
+        var tab = requestedTab();
+        var button = document.querySelector('.tab-button[data-audit-tab="' + tab + '"]')
+                || document.querySelector('.tab-button[data-audit-tab="history"]');
+        openTab({ currentTarget: button, isTrusted: false }, button.getAttribute('data-tab-content'), button.getAttribute('data-audit-tab'));
+    }
+
+    activateRequestedTab();
+    fetch('<%=request.getContextPath()%>/app/TabAudit', {
+        method: 'POST',
+        credentials: 'include',
+        cache: 'no-store',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8' },
+        body: 'tab=' + encodeURIComponent('landing')
+    }).catch(function () {
+        // keep landing resilient even if audit logging fails
+    });
 </script>
 </body>
 </html>

--- a/src/main/webapp/app/index.jsp
+++ b/src/main/webapp/app/index.jsp
@@ -9,6 +9,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <%@ include file="/WEB-INF/jspf/head-common.jspf" %>
     <title>Frankies Bootcamp</title>
     <script>
@@ -26,28 +27,62 @@
             evt.currentTarget.classList.add("active");
         }
     </script>
+    <style>
+        #appBottomTabs {
+            position: fixed;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            z-index: 1030;
+            background: #fff;
+            border-top: 1px solid #dee2e6;
+            box-shadow: 0 -0.25rem 0.75rem rgba(0, 0, 0, 0.08);
+        }
+
+        #appBottomTabs .tab-button {
+            flex: 1 1 20%;
+            min-width: 0;
+            border: 0;
+            background: transparent;
+            color: #6c757d;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            gap: 0.1rem;
+            padding: 0.45rem 0.15rem calc(0.45rem + env(safe-area-inset-bottom, 0px));
+            font-size: 0.72rem;
+            line-height: 1.1;
+            text-align: center;
+            white-space: nowrap;
+        }
+
+        #appBottomTabs .tab-button .header-icon {
+            font-size: 1rem;
+            margin-right: 0;
+        }
+
+        #appBottomTabs .tab-button.active,
+        #appBottomTabs .tab-button:hover {
+            color: #0d6efd;
+            border-bottom: 0;
+            background: rgba(13, 110, 253, 0.08);
+        }
+
+        #appBottomTabs + .main-content-wrapper {
+            padding-bottom: calc(4.8rem + env(safe-area-inset-bottom, 0px));
+        }
+    </style>
 </head>
-<body>
+<body class="has-bottom-tabs">
 <%@ include file="/WEB-INF/jspf/header.jspf" %>
 
-<!-- Tabs Container -->
-<div id="tabsContainer" class="overflow-auto"
-     style="position: sticky; top: 56px; z-index: 1020; background-color: white; border-bottom: 1px solid #ddd;">
-    <div class="d-flex flex-row flex-nowrap">
-        <button class="tab-button active" onclick="openTab(event, 'Tab1Content', 'history')"><i
-                class="bi bi-hourglass-bottom header-icon"></i>Weekly History
-        </button>
-        <button class="tab-button" onclick="openTab(event, 'Tab3Content', 'leaderboard')"><i
-                class='bi bi-bar-chart-line-fill header-icon'></i>Leaderboard
-        </button>
-        <button class="tab-button" onclick="openTab(event, 'Tab2Content', 'honour-roll')"><i class="bi bi-trophy-fill header-icon"></i>Honour
-            Roll
-        </button>
-        <button class="tab-button" onclick="openTab(event, 'Tab4Content', 'summary')"><i class="bi bi-list-ol header-icon"></i>Summary
-        </button>
-        <button class="tab-button" onclick="openTab(event, 'Tab8Content', 'insights')"><i class="bi bi-lightbulb-fill header-icon"></i>Insights
-        </button>
-    </div>
+<div id="appBottomTabs" class="d-flex flex-row flex-nowrap">
+    <button class="tab-button active" onclick="openTab(event, 'Tab1Content', 'history')"><i class="bi bi-hourglass-bottom header-icon"></i><span>History</span></button>
+    <button class="tab-button" onclick="openTab(event, 'Tab2Content', 'leaderboard')"><i class="bi bi-bar-chart-line-fill header-icon"></i><span>Board</span></button>
+    <button class="tab-button" onclick="openTab(event, 'Tab3Content', 'honour-roll')"><i class="bi bi-trophy-fill header-icon"></i><span>Roll</span></button>
+    <button class="tab-button" onclick="openTab(event, 'Tab4Content', 'insights')"><i class="bi bi-lightbulb-fill header-icon"></i><span>Insights</span></button>
+    <button class="tab-button" onclick="openTab(event, 'Tab5Content', 'help')"><i class="bi bi-info-circle header-icon"></i><span>Help</span></button>
 </div>
 
 <div class="main-content-wrapper">
@@ -56,30 +91,103 @@
             <jsp:include page="/app/AthleteHistory"/>
         </div>
         <div id="Tab2Content" class="tab-content">
-            <jsp:include page="/app/HonourRoll"/>
-        </div>
-        <div id="Tab3Content" class="tab-content">
             <jsp:include page="/app/LeaderBoard"/>
         </div>
+        <div id="Tab3Content" class="tab-content">
+            <jsp:include page="/app/HonourRoll"/>
+        </div>
         <div id="Tab4Content" class="tab-content">
-            <jsp:include page="/app/AthleteSummary"/>
+            <jsp:include page="/app/Insights"/>
         </div>
         <div id="Tab5Content" class="tab-content">
-            <%@ include file="/WEB-INF/jspf/scoring-content.jspf" %>
-        </div>
-        <div id="Tab6Content" class="tab-content">
-            <%@ include file="/WEB-INF/jspf/terms-content.jspf" %>
-        </div>
-        <div id="Tab7Content" class="tab-content">
-            <%@ include file="/WEB-INF/jspf/privacy-content.jspf" %>
-        </div>
-        <div id="Tab8Content" class="tab-content">
-            <jsp:include page="/app/Insights"/>
+            <div class="container py-3">
+                <div class="row justify-content-center">
+                    <div class="col-lg-8">
+                        <div class="card shadow-sm border-0">
+                            <div class="card-body p-4">
+                                <h1 class="h4 mb-3">Help</h1>
+                                <p class="text-muted mb-4">Tap a section to open it in a clean modal.</p>
+                                <div class="d-grid gap-2">
+                                    <button class="btn btn-outline-primary btn-lg" type="button" data-bs-toggle="modal" data-bs-target="#helpScoringModal">
+                                        Scoring
+                                    </button>
+                                    <button class="btn btn-outline-primary btn-lg" type="button" data-bs-toggle="modal" data-bs-target="#helpTermsModal">
+                                        Terms of Service
+                                    </button>
+                                    <button class="btn btn-outline-primary btn-lg" type="button" data-bs-toggle="modal" data-bs-target="#helpPrivacyModal">
+                                        Privacy Policy
+                                    </button>
+                                    <button class="btn btn-outline-primary btn-lg" type="button" data-bs-toggle="modal" data-bs-target="#helpContactModal">
+                                        Contact us
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 </div>
 
 <%@ include file="/WEB-INF/jspf/zenbot.jspf" %>
+
+<div class="modal fade" id="helpScoringModal" tabindex="-1" aria-labelledby="helpScoringModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-xl modal-dialog-scrollable">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="helpScoringModalLabel">Scoring</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body p-0">
+                <%@ include file="/WEB-INF/jspf/scoring-content.jspf" %>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="helpTermsModal" tabindex="-1" aria-labelledby="helpTermsModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-xl modal-dialog-scrollable">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="helpTermsModalLabel">Terms of Service</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body p-0">
+                <%@ include file="/WEB-INF/jspf/terms-content.jspf" %>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="helpPrivacyModal" tabindex="-1" aria-labelledby="helpPrivacyModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-xl modal-dialog-scrollable">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="helpPrivacyModalLabel">Privacy Policy</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body p-0">
+                <%@ include file="/WEB-INF/jspf/privacy-content.jspf" %>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="helpContactModal" tabindex="-1" aria-labelledby="helpContactModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="helpContactModalLabel">Contact us</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <p class="mb-3">Questions, bugs, or gentle roast requests:</p>
+                <a class="btn btn-primary" href="mailto:support@mail.frankiesbootamp.com">support@mail.frankiesbootamp.com</a>
+            </div>
+        </div>
+    </div>
+</div>
 
 <script>
     document.getElementsByClassName("tab-button")[0].click(); // Default to first tab

--- a/src/main/webapp/app/invitations.jsp
+++ b/src/main/webapp/app/invitations.jsp
@@ -1,0 +1,120 @@
+<%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%@ page import="com.frankies.bootcamp.model.CompetitionInvitationView" %>
+<%@ page import="com.frankies.bootcamp.model.BootcampAthlete" %>
+<%@ page import="java.util.List" %>
+<%
+    List<CompetitionInvitationView> invitations = (List<CompetitionInvitationView>) request.getAttribute("pendingCompetitionInvitations");
+    CompetitionInvitationView pendingInvitation = (CompetitionInvitationView) request.getAttribute("pendingInvitation");
+    BootcampAthlete athlete = (BootcampAthlete) request.getAttribute("athlete");
+    Double suggestedGoal = athlete == null ? null : athlete.getGoal();
+    String pageContextPath = request.getContextPath();
+    String error = request.getParameter("error");
+    String status = request.getParameter("status");
+%>
+<%!
+    private String escapeHtml(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&#39;");
+    }
+
+    private String maskEmail(String email) {
+        if (email == null || email.isBlank()) {
+            return "";
+        }
+        if (email.length() <= 5) {
+            return email;
+        }
+        int at = email.indexOf('@');
+        if (at <= 0) {
+            return email;
+        }
+        String localPart = email.substring(0, at);
+        String domain = email.substring(at);
+        if (localPart.length() <= 2) {
+            return localPart.substring(0, 1) + "***" + domain;
+        }
+        return localPart.substring(0, 1) + "***" + localPart.substring(localPart.length() - 1) + domain;
+    }
+%>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <%@ include file="/WEB-INF/jspf/head-common.jspf" %>
+    <title>Invitations</title>
+</head>
+<body class="bg-light">
+<%@ include file="/WEB-INF/jspf/header.jspf" %>
+
+<div class="container py-4">
+    <div class="row justify-content-center">
+        <div class="col-lg-9">
+            <% if (status != null && !status.isBlank()) { %>
+            <div class="alert alert-success" role="alert">Invitation <%= escapeHtml(status) %>.</div>
+            <% } %>
+            <% if (error != null && !error.isBlank()) { %>
+            <div class="alert alert-danger" role="alert"><%= escapeHtml(error) %></div>
+            <% } %>
+
+            <div class="card shadow-sm border-0 mb-4">
+                <div class="card-body p-4">
+                    <h1 class="h4 mb-3">Pending invitations</h1>
+                    <% if (invitations == null || invitations.isEmpty()) { %>
+                    <div class="alert alert-info mb-0">No pending invitations right now.</div>
+                    <% } else { %>
+                    <div class="row g-3">
+                        <% for (CompetitionInvitationView invitation : invitations) { %>
+                        <div class="col-12">
+                            <div class="border rounded p-3 bg-white">
+                                <div class="d-flex justify-content-between align-items-start gap-3 flex-wrap">
+                                    <div>
+                                        <div class="fw-semibold"><%= escapeHtml(invitation.getCompetitionName()) %></div>
+                                        <div class="text-muted small"><%= escapeHtml(maskEmail(invitation.getInvitedEmail())) %></div>
+                                    </div>
+                                    <span class="badge text-bg-warning">Pending</span>
+                                </div>
+                                <form class="mt-3" method="post" action="<%=pageContextPath%>/app/invitations/respond">
+                                    <input type="hidden" name="invitationId" value="<%= invitation.getId() %>">
+                                    <input type="hidden" name="token" value="<%= invitation.getToken() %>">
+                                    <div class="row g-2 align-items-end">
+                                        <div class="col-sm-4">
+                                            <label class="form-label" for="startingGoal-<%=invitation.getId()%>">Starting goal</label>
+                                            <input class="form-control" id="startingGoal-<%=invitation.getId()%>" name="startingGoal" type="number" min="0" step="0.1"
+                                                   value="<%= suggestedGoal == null ? "0" : suggestedGoal %>">
+                                        </div>
+                                        <div class="col-sm-8 text-sm-end">
+                                            <button class="btn btn-primary" type="submit" name="action" value="accept">Accept</button>
+                                            <button class="btn btn-outline-secondary" type="submit" name="action" value="decline">Decline</button>
+                                        </div>
+                                    </div>
+                                </form>
+                            </div>
+                        </div>
+                        <% } %>
+                    </div>
+                    <% } %>
+                </div>
+            </div>
+
+            <% if (pendingInvitation != null && (invitations == null || invitations.stream().noneMatch(inv -> inv.getId() == pendingInvitation.getId()))) { %>
+            <div class="alert alert-primary" role="alert">
+                Invitation loaded for <strong><%= escapeHtml(pendingInvitation.getCompetitionName()) %></strong>.
+            </div>
+            <% } %>
+
+            <div class="d-grid gap-2 d-sm-flex justify-content-sm-center">
+                <a class="btn btn-outline-secondary btn-lg" href="<%=pageContextPath%>/app/">Back to dashboard</a>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/webapp/app/invitations.jsp
+++ b/src/main/webapp/app/invitations.jsp
@@ -77,7 +77,13 @@
                                 <div class="d-flex justify-content-between align-items-start gap-3 flex-wrap">
                                     <div>
                                         <div class="fw-semibold"><%= escapeHtml(invitation.getCompetitionName()) %></div>
-                                        <div class="text-muted small"><%= escapeHtml(maskEmail(invitation.getInvitedEmail())) %></div>
+                                        <div class="text-muted small">
+                                            <% if (invitation.getInvitedUserId() != null && !invitation.getInvitedUserId().isBlank()) { %>
+                                            Invite linked to your account
+                                            <% } else { %>
+                                            <%= escapeHtml(maskEmail(invitation.getInvitedEmail())) %>
+                                            <% } %>
+                                        </div>
                                     </div>
                                     <span class="badge text-bg-warning">Pending</span>
                                 </div>

--- a/src/main/webapp/app/whoami.jsp
+++ b/src/main/webapp/app/whoami.jsp
@@ -44,7 +44,11 @@
   Object athlete = session.getAttribute("athlete");
   if (athlete instanceof com.frankies.bootcamp.model.BootcampAthlete) {
     String athleteId = ((com.frankies.bootcamp.model.BootcampAthlete) athlete).getId();
+    String profileMedium = ((com.frankies.bootcamp.model.BootcampAthlete) athlete).getProfileMedium();
     stravaLinked = athleteId != null && !athleteId.startsWith("local-");
+    if (profileMedium != null && !profileMedium.isBlank()) {
+      json.append(",\"profileMedium\":\"").append(jsonEscape(profileMedium)).append("\"");
+    }
   }
   boolean authed = (email != null);
 

--- a/src/main/webapp/app/whoami.jsp
+++ b/src/main/webapp/app/whoami.jsp
@@ -36,6 +36,7 @@
   String name  = (String) session.getAttribute("athleteName");
   String email = (String) session.getAttribute("athleteEmail");
   String handle = null;
+  String profileMedium = null;
   boolean stravaLinked = false;
   Object authUser = session.getAttribute("authUser");
   if (authUser instanceof com.frankies.bootcamp.model.AuthenticatedUser) {
@@ -44,11 +45,8 @@
   Object athlete = session.getAttribute("athlete");
   if (athlete instanceof com.frankies.bootcamp.model.BootcampAthlete) {
     String athleteId = ((com.frankies.bootcamp.model.BootcampAthlete) athlete).getId();
-    String profileMedium = ((com.frankies.bootcamp.model.BootcampAthlete) athlete).getProfileMedium();
+    profileMedium = ((com.frankies.bootcamp.model.BootcampAthlete) athlete).getProfileMedium();
     stravaLinked = athleteId != null && !athleteId.startsWith("local-");
-    if (profileMedium != null && !profileMedium.isBlank()) {
-      json.append(",\"profileMedium\":\"").append(jsonEscape(profileMedium)).append("\"");
-    }
   }
   boolean authed = (email != null);
 
@@ -59,6 +57,9 @@
     json.append(",\"email\":\"").append(jsonEscape(email)).append("\"");
     if (handle != null) json.append(",\"handle\":\"").append(jsonEscape(handle)).append("\"");
     json.append(",\"stravaLinked\":").append(stravaLinked ? "true" : "false");
+    if (profileMedium != null && !profileMedium.isBlank()) {
+      json.append(",\"profileMedium\":\"").append(jsonEscape(profileMedium)).append("\"");
+    }
   }
   json.append('}');
 

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -38,7 +38,7 @@
 
             <div class="mb-4 d-flex flex-wrap gap-2">
                 <a class="btn btn-primary btn-lg" href="<%=request.getContextPath()%>/login">Login</a>
-                <a class="btn btn-outline-primary btn-lg" href="<%=request.getContextPath()%>/join">Join</a>
+                <a class="btn btn-outline-primary btn-lg" href="<%=request.getContextPath()%>/invite">Use an invitation</a>
                 <a class="btn btn-outline-primary btn-lg" href="<%=request.getContextPath()%>/scoring">See how scoring works</a>
             </div>
 

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -1,8 +1,15 @@
+<%@ page import="com.frankies.bootcamp.model.AuthenticatedUser" %>
 <%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <%
     response.setHeader("Cache-Control", "no-store, no-cache, must-revalidate");
     response.addHeader("Cache-Control", "post-check=0, pre-check=0");
     response.setHeader("Pragma", "no-cache");
+    boolean landingLoggedIn = session.getAttribute("authUser") instanceof AuthenticatedUser;
+    String landingPrimaryHref = request.getContextPath() + (landingLoggedIn ? "/app/" : "/login");
+    String landingPrimaryLabel = landingLoggedIn ? "Go to dashboard" : "Login";
+    String landingAlertSuffix = landingLoggedIn
+            ? " to open your dashboard."
+            : " to sign in or create your account through Auth0, then head to your dashboard.";
 %>
 <!doctype html>
 <html>
@@ -37,7 +44,7 @@
             </p>
 
             <div class="mb-4 d-flex flex-wrap gap-2">
-                <a class="btn btn-primary btn-lg" href="<%=request.getContextPath()%>/login">Login</a>
+                <a class="btn btn-primary btn-lg" href="<%= landingPrimaryHref %>"><%= landingPrimaryLabel %></a>
                 <a class="btn btn-outline-primary btn-lg" href="<%=request.getContextPath()%>/invite">Use an invitation</a>
                 <a class="btn btn-outline-primary btn-lg" href="<%=request.getContextPath()%>/scoring">See how scoring works</a>
             </div>
@@ -75,8 +82,7 @@
             <!-- info box: change /auth/login -> /app/ -->
             <div class="alert alert-info">
                 Ready to join or already have an account?
-                <a class="alert-link" href="<%=request.getContextPath()%>/login">Login</a>
-                to sign in or create your account through Auth0, then head to your dashboard.
+                <a class="alert-link" href="<%= landingPrimaryHref %>"><%= landingPrimaryLabel %></a><%= landingAlertSuffix %>
             </div>
         </div>
     </div>

--- a/src/main/webapp/invite.jsp
+++ b/src/main/webapp/invite.jsp
@@ -1,0 +1,95 @@
+<%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%@ page import="com.frankies.bootcamp.model.CompetitionInvitationView" %>
+<%@ page import="com.frankies.bootcamp.model.AuthenticatedUser" %>
+<%
+    CompetitionInvitationView invitation = (CompetitionInvitationView) request.getAttribute("invitation");
+    String error = (String) request.getAttribute("inviteError");
+    String pageContextPath = request.getContextPath();
+    AuthenticatedUser authUser = (AuthenticatedUser) session.getAttribute("authUser");
+    boolean loggedIn = authUser != null && authUser.getUserId() != null && !authUser.getUserId().isBlank();
+%>
+<%!
+    private String escapeHtml(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&#39;");
+    }
+%>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <%@ include file="/WEB-INF/jspf/head-common.jspf" %>
+    <title>Competition invitation</title>
+</head>
+<body class="bg-light">
+<header class="d-flex align-items-center justify-content-between text-white px-3 py-2 shadow-sm"
+        style="min-height:56px; background-color: #0d6efd;">
+    <a href="<%=pageContextPath%>/" class="text-white text-decoration-none d-flex align-items-center gap-2">
+        <span aria-hidden="true">&#x1F3CB;&#xFE0F;</span>
+        <span>Frankies Bootcamp!</span>
+    </a>
+</header>
+
+<div class="container py-5">
+    <div class="row justify-content-center">
+        <div class="col-lg-8">
+            <div class="card shadow-sm border-0">
+                <div class="card-body p-4 p-md-5">
+                    <div class="text-center mb-4">
+                        <div class="display-5 text-primary mb-3"><i class="bi bi-envelope-paper"></i></div>
+                        <h1 class="h3 mb-3">You have a competition invitation</h1>
+                    </div>
+
+                    <% if (error != null && !error.isBlank()) { %>
+                    <div class="alert alert-warning" role="alert"><%= escapeHtml(error) %></div>
+                    <% } else if (invitation != null) { %>
+                    <div class="alert alert-primary" role="alert">
+                        <strong><%= escapeHtml(invitation.getCompetitionName()) %></strong>
+                        <% if (invitation.getInvitedEmail() != null) { %>
+                        was sent to <strong><%= escapeHtml(invitation.getInvitedEmail()) %></strong>.
+                        <% } %>
+                    </div>
+                    <% if (loggedIn) { %>
+                    <p class="text-muted">
+                        Accept this invitation to join the competition. If you do not have Strava linked yet, you will be sent there after accept.
+                    </p>
+                    <form method="post" action="<%=pageContextPath%>/app/invitations/respond" class="mt-4">
+                        <input type="hidden" name="invitationId" value="<%= invitation.getId() %>">
+                        <input type="hidden" name="token" value="<%= invitation.getToken() %>">
+                        <div class="d-grid gap-2 d-sm-flex justify-content-sm-center">
+                            <button class="btn btn-primary btn-lg" type="submit" name="action" value="accept">Accept invite</button>
+                            <button class="btn btn-outline-secondary btn-lg" type="submit" name="action" value="decline">Decline</button>
+                        </div>
+                    </form>
+                    <% } else { %>
+                    <p class="text-muted">
+                        Sign in or create your account, then link Strava if needed. We will keep this invitation with your session.
+                    </p>
+                    <% } %>
+                    <% } else { %>
+                    <div class="alert alert-info" role="alert">
+                        This invitation link is missing or invalid.
+                    </div>
+                    <% } %>
+
+                    <% if (!loggedIn) { %>
+                    <div class="d-grid gap-2 d-sm-flex justify-content-sm-center mt-4">
+                        <a class="btn btn-primary btn-lg" href="<%=pageContextPath%>/login?prompt=login">Sign in</a>
+                        <a class="btn btn-outline-secondary btn-lg" href="<%=pageContextPath%>/">Back to home</a>
+                    </div>
+                    <% } %>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/webapp/invite.jsp
+++ b/src/main/webapp/invite.jsp
@@ -7,6 +7,7 @@
     String pageContextPath = request.getContextPath();
     AuthenticatedUser authUser = (AuthenticatedUser) session.getAttribute("authUser");
     boolean loggedIn = authUser != null && authUser.getUserId() != null && !authUser.getUserId().isBlank();
+    String tokenParam = request.getParameter("token");
 %>
 <%!
     private String escapeHtml(String value) {
@@ -48,12 +49,23 @@
                         <h1 class="h3 mb-3">You have a competition invitation</h1>
                     </div>
 
+                    <form method="post" action="<%=pageContextPath%>/invite" class="mb-4">
+                        <label class="form-label" for="token">Paste invitation token</label>
+                        <div class="input-group">
+                            <input class="form-control" id="token" name="token" value="<%= escapeHtml(tokenParam == null ? "" : tokenParam) %>" placeholder="Paste the token or invite link from your email">
+                            <button class="btn btn-outline-primary" type="submit">Open invite</button>
+                        </div>
+                        <div class="form-text">Paste the raw token or the full invite link and we’ll open the right invitation.</div>
+                    </form>
+
                     <% if (error != null && !error.isBlank()) { %>
                     <div class="alert alert-warning" role="alert"><%= escapeHtml(error) %></div>
                     <% } else if (invitation != null) { %>
                     <div class="alert alert-primary" role="alert">
                         <strong><%= escapeHtml(invitation.getCompetitionName()) %></strong>
-                        <% if (invitation.getInvitedEmail() != null) { %>
+                        <% if (invitation.getInvitedUserId() != null && !invitation.getInvitedUserId().isBlank()) { %>
+                        is linked to your account.
+                        <% } else if (invitation.getInvitedEmail() != null) { %>
                         was sent to <strong><%= escapeHtml(invitation.getInvitedEmail()) %></strong>.
                         <% } %>
                     </div>

--- a/src/main/webapp/styles/main.css
+++ b/src/main/webapp/styles/main.css
@@ -535,6 +535,10 @@ table th i {
         bottom: 12px;
     }
 
+    body.has-bottom-tabs #zenbotWidget {
+        bottom: calc(12px + 1.4rem + env(safe-area-inset-bottom, 0px));
+    }
+
     #zenbotBackdrop {
         background: rgba(18, 31, 53, 0.18);
     }
@@ -554,6 +558,10 @@ table th i {
     flex-direction: column;
     align-items: flex-end;
     gap: 12px;
+}
+
+body.has-bottom-tabs #zenbotWidget {
+    bottom: calc(20px + 3.9rem + env(safe-area-inset-bottom, 0px));
 }
 
 #zenbotBackdrop {

--- a/src/test/java/com/frankies/bootcamp/auth/AuthSessionServiceTest.java
+++ b/src/test/java/com/frankies/bootcamp/auth/AuthSessionServiceTest.java
@@ -28,6 +28,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -71,6 +72,16 @@ class AuthSessionServiceTest {
         service.clear(request);
 
         assertTrue(session.invalidated);
+    }
+
+    @Test
+    void historyMotivationalMessageHiddenFlagPersistsInSession() {
+        AuthSessionService service = new AuthSessionService();
+        FakeHttpServletRequest request = new FakeHttpServletRequest("", new FakeHttpSession());
+
+        assertFalse(service.isHistoryMotivationalMessageHidden(request));
+        service.hideHistoryMotivationalMessage(request);
+        assertTrue(service.isHistoryMotivationalMessageHidden(request));
     }
 
     @Test

--- a/src/test/java/com/frankies/bootcamp/service/CompetitionInsightsServiceTest.java
+++ b/src/test/java/com/frankies/bootcamp/service/CompetitionInsightsServiceTest.java
@@ -50,6 +50,8 @@ class CompetitionInsightsServiceTest {
         assertEquals("Alex", profile.athleteName());
         assertEquals(1, profile.overallRank());
         assertEquals("", profile.totalDistanceDisplay());
+        assertEquals(3.8, profile.totalScore(), 0.0001);
+        assertEquals(0.8, profile.currentWeekPercentOfGoal(), 0.0001);
         assertEquals(2, profile.goalCrushWeeks());
         assertEquals(2, profile.activeWeeks());
         assertEquals("Ride", profile.strongestSport());

--- a/src/test/java/com/frankies/bootcamp/service/CompetitionInvitationServiceTest.java
+++ b/src/test/java/com/frankies/bootcamp/service/CompetitionInvitationServiceTest.java
@@ -1,0 +1,284 @@
+package com.frankies.bootcamp.service;
+
+import com.frankies.bootcamp.model.CompetitionInviteCandidateView;
+import com.frankies.bootcamp.model.CompetitionInvitationView;
+import com.frankies.bootcamp.model.CompetitionSummaryView;
+import org.junit.jupiter.api.Test;
+
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CompetitionInvitationServiceTest {
+
+    @Test
+    void bulkInviteDedupesWithinSubmittedListAndSendsEmail() throws Exception {
+        FakeRepository repository = new FakeRepository();
+        repository.competitions.put(7L, new CompetitionSummaryView(7L, "Winter Bootcamp", "Australia/Sydney", Instant.now().getEpochSecond(), null, "active"));
+        RecordingEmailService emailService = new RecordingEmailService();
+        CompetitionInvitationService service = new CompetitionInvitationService(repository, emailService);
+
+        CompetitionInvitationService.InviteSubmissionResult result = service.inviteByEmails(7L, "usr-admin", "ALICE@example.com, alice@example.com;bob@example.com", null);
+
+        assertEquals(2, result.createdInvites().size());
+        assertEquals(2, repository.invites.size());
+        assertEquals(2, emailService.sentSubjects.size());
+    }
+
+    @Test
+    void inviteExistingUserRejectsAlreadyActiveMembers() throws Exception {
+        FakeRepository repository = new FakeRepository();
+        repository.activeMembers.add("athlete-1");
+        CompetitionInvitationService service = new CompetitionInvitationService(repository, new RecordingEmailService());
+
+        assertThrows(IllegalArgumentException.class,
+                () -> service.inviteExistingUser(7L, "usr-admin", "athlete-1", "athlete@example.com", null));
+    }
+
+    @Test
+    void acceptInvitationCreatesMembershipAndMarksInviteAccepted() throws Exception {
+        FakeRepository repository = new FakeRepository();
+        repository.competitions.put(7L, new CompetitionSummaryView(7L, "Winter Bootcamp", "Australia/Sydney", Instant.now().getEpochSecond(), null, "active"));
+        CompetitionInvitationView invitation = repository.createStoredInvitation(7L, "athlete@example.com", "usr-1");
+        CompetitionInvitationService service = new CompetitionInvitationService(repository, new RecordingEmailService());
+        com.frankies.bootcamp.model.BootcampAthlete athlete = new com.frankies.bootcamp.model.BootcampAthlete();
+        athlete.setId("athlete-1");
+
+        CompetitionInvitationService.InvitationDecisionResult result = service.acceptInvitation(invitation.getId(), athlete, 24.5, "usr-1");
+
+        assertTrue(result.success());
+        assertTrue(repository.activeMembers.contains("athlete-1"));
+        assertEquals("accepted", repository.invites.get(invitation.getId()).getStatus());
+    }
+
+    @Test
+    void resolveInvitationTokenExpiresStaleInvites() throws Exception {
+        FakeRepository repository = new FakeRepository();
+        CompetitionInvitationView invitation = repository.createStoredInvitation(7L, "athlete@example.com", "usr-1");
+        repository.invites.put(invitation.getId(), new CompetitionInvitationView(
+                invitation.getId(),
+                invitation.getCompetitionId(),
+                invitation.getCompetitionName(),
+                invitation.getInvitedEmail(),
+                invitation.getInvitedUserId(),
+                invitation.getToken(),
+                "pending",
+                invitation.getInvitedByUserId(),
+                invitation.getCreatedAt(),
+                invitation.getUpdatedAt(),
+                Instant.now().minusSeconds(60),
+                invitation.getAcceptedAt(),
+                invitation.getDeclinedAt()
+        ));
+        CompetitionInvitationService service = new CompetitionInvitationService(repository, new RecordingEmailService());
+
+        CompetitionInvitationView resolved = service.resolveInvitationToken(invitation.getToken());
+
+        assertNotNull(resolved);
+        assertEquals("expired", resolved.getStatus());
+    }
+
+    private static final class RecordingEmailService extends CompetitionInvitationEmailService {
+        private final List<String> sentSubjects = new ArrayList<>();
+
+        private RecordingEmailService() {
+            super();
+        }
+
+        @Override
+        public boolean sendInvitation(String to, String subject, String body) {
+            sentSubjects.add(subject);
+            return true;
+        }
+    }
+
+    private static final class FakeRepository implements CompetitionInvitationService.InvitationRepository {
+        private final Map<Long, CompetitionInvitationView> invites = new LinkedHashMap<>();
+        private final Map<Long, CompetitionSummaryView> competitions = new HashMap<>();
+        private final Map<String, Boolean> admins = new HashMap<>();
+        private final List<String> activeMembers = new ArrayList<>();
+        private long nextId = 1L;
+
+        private CompetitionInvitationView createStoredInvitation(long competitionId, String email, String invitedByUserId) {
+            long id = nextId++;
+            String token = "token-" + id;
+            CompetitionInvitationView invitation = new CompetitionInvitationView(
+                    id,
+                    competitionId,
+                    competitions.get(competitionId) == null ? "Competition" : competitions.get(competitionId).getName(),
+                    email,
+                    null,
+                    token,
+                    "pending",
+                    invitedByUserId,
+                    Instant.now(),
+                    Instant.now(),
+                    Instant.now().plusSeconds(3600),
+                    null,
+                    null
+            );
+            invites.put(id, invitation);
+            return invitation;
+        }
+
+        @Override
+        public boolean isCompetitionAdmin(long competitionId, String athleteId) {
+            return admins.getOrDefault(competitionId + ":" + athleteId, Boolean.FALSE);
+        }
+
+        @Override
+        public boolean athleteBelongsToCompetition(String athleteId, long competitionId) {
+            return activeMembers.contains(athleteId);
+        }
+
+        @Override
+        public boolean hasActiveInvitationForEmail(long competitionId, String normalizedEmail) {
+            return invites.values().stream().anyMatch(inv -> inv.getCompetitionId() == competitionId
+                    && normalizedEmail.equals(inv.getInvitedEmail())
+                    && "pending".equals(inv.getStatus()));
+        }
+
+        @Override
+        public boolean hasActiveInvitationForUser(long competitionId, String invitedUserId) {
+            return invites.values().stream().anyMatch(inv -> inv.getCompetitionId() == competitionId
+                    && invitedUserId != null
+                    && invitedUserId.equals(inv.getInvitedUserId())
+                    && "pending".equals(inv.getStatus()));
+        }
+
+        @Override
+        public long createInvitation(long competitionId, String invitedEmail, String invitedUserId, String token, String invitedByUserId, Instant expiresAt) {
+            long id = nextId++;
+            CompetitionInvitationView invitation = new CompetitionInvitationView(
+                    id,
+                    competitionId,
+                    competitions.get(competitionId) == null ? "Competition" : competitions.get(competitionId).getName(),
+                    invitedEmail,
+                    invitedUserId,
+                    token,
+                    "pending",
+                    invitedByUserId,
+                    Instant.now(),
+                    Instant.now(),
+                    expiresAt,
+                    null,
+                    null
+            );
+            invites.put(id, invitation);
+            return id;
+        }
+
+        @Override
+        public CompetitionInvitationView findInvitationByToken(String token) {
+            return invites.values().stream().filter(inv -> token.equals(inv.getToken())).findFirst().orElse(null);
+        }
+
+        @Override
+        public CompetitionInvitationView findInvitationById(long invitationId) {
+            return invites.get(invitationId);
+        }
+
+        @Override
+        public List<CompetitionInvitationView> listPendingInvitationsForUser(String userId, String email, String athleteId) {
+            return invites.values().stream()
+                    .filter(CompetitionInvitationView::isPending)
+                    .filter(inv -> (userId != null && userId.equals(inv.getInvitedUserId()))
+                            || (email != null && email.equals(inv.getInvitedEmail())))
+                    .toList();
+        }
+
+        @Override
+        public List<CompetitionInvitationView> listPendingInvitationsForCompetition(long competitionId) {
+            return invites.values().stream()
+                    .filter(inv -> inv.getCompetitionId() == competitionId)
+                    .filter(CompetitionInvitationView::isPending)
+                    .toList();
+        }
+
+        @Override
+        public List<CompetitionInviteCandidateView> searchInviteCandidates(long competitionId, String query) {
+            return List.of();
+        }
+
+        @Override
+        public void acceptInvitation(long invitationId, String athleteId, double startingGoal) {
+            CompetitionInvitationView invitation = invites.get(invitationId);
+            invites.put(invitationId, new CompetitionInvitationView(
+                    invitation.getId(),
+                    invitation.getCompetitionId(),
+                    invitation.getCompetitionName(),
+                    invitation.getInvitedEmail(),
+                    invitation.getInvitedUserId(),
+                    invitation.getToken(),
+                    "accepted",
+                    invitation.getInvitedByUserId(),
+                    invitation.getCreatedAt(),
+                    invitation.getUpdatedAt(),
+                    invitation.getExpiresAt(),
+                    Instant.now(),
+                    invitation.getDeclinedAt()
+            ));
+            activeMembers.add(athleteId);
+        }
+
+        @Override
+        public void declineInvitation(long invitationId) {
+            CompetitionInvitationView invitation = invites.get(invitationId);
+            invites.put(invitationId, new CompetitionInvitationView(
+                    invitation.getId(),
+                    invitation.getCompetitionId(),
+                    invitation.getCompetitionName(),
+                    invitation.getInvitedEmail(),
+                    invitation.getInvitedUserId(),
+                    invitation.getToken(),
+                    "declined",
+                    invitation.getInvitedByUserId(),
+                    invitation.getCreatedAt(),
+                    invitation.getUpdatedAt(),
+                    invitation.getExpiresAt(),
+                    invitation.getAcceptedAt(),
+                    Instant.now()
+            ));
+        }
+
+        @Override
+        public void expireInvitation(long invitationId) {
+            CompetitionInvitationView invitation = invites.get(invitationId);
+            invites.put(invitationId, new CompetitionInvitationView(
+                    invitation.getId(),
+                    invitation.getCompetitionId(),
+                    invitation.getCompetitionName(),
+                    invitation.getInvitedEmail(),
+                    invitation.getInvitedUserId(),
+                    invitation.getToken(),
+                    "expired",
+                    invitation.getInvitedByUserId(),
+                    invitation.getCreatedAt(),
+                    invitation.getUpdatedAt(),
+                    invitation.getExpiresAt(),
+                    invitation.getAcceptedAt(),
+                    invitation.getDeclinedAt()
+            ));
+        }
+
+        @Override
+        public CompetitionInvitationView getInvitationForCompetitionAndToken(long competitionId, String token) {
+            return findInvitationByToken(token);
+        }
+
+        @Override
+        public CompetitionSummaryView findCompetition(long competitionId) {
+            return competitions.get(competitionId);
+        }
+    }
+}

--- a/src/test/java/com/frankies/bootcamp/service/CompetitionInvitationServiceTest.java
+++ b/src/test/java/com/frankies/bootcamp/service/CompetitionInvitationServiceTest.java
@@ -3,6 +3,7 @@ package com.frankies.bootcamp.service;
 import com.frankies.bootcamp.model.CompetitionInviteCandidateView;
 import com.frankies.bootcamp.model.CompetitionInvitationView;
 import com.frankies.bootcamp.model.CompetitionSummaryView;
+import com.frankies.bootcamp.model.BootcampAthlete;
 import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
@@ -28,11 +29,12 @@ class CompetitionInvitationServiceTest {
         RecordingEmailService emailService = new RecordingEmailService();
         CompetitionInvitationService service = new CompetitionInvitationService(repository, emailService);
 
-        CompetitionInvitationService.InviteSubmissionResult result = service.inviteByEmails(7L, "usr-admin", "ALICE@example.com, alice@example.com;bob@example.com", null);
+        CompetitionInvitationService.InviteSubmissionResult result = service.inviteByEmails(7L, "usr-admin", "ALICE@example.com, alice@example.com;bob@example.com", "Keep it up!", null);
 
         assertEquals(2, result.createdInvites().size());
         assertEquals(2, repository.invites.size());
         assertEquals(2, emailService.sentSubjects.size());
+        assertTrue(emailService.sentBodies.get(0).contains("Keep it up!"));
     }
 
     @Test
@@ -42,7 +44,7 @@ class CompetitionInvitationServiceTest {
         CompetitionInvitationService service = new CompetitionInvitationService(repository, new RecordingEmailService());
 
         assertThrows(IllegalArgumentException.class,
-                () -> service.inviteExistingUser(7L, "usr-admin", "athlete-1", "athlete@example.com", null));
+                () -> service.inviteExistingUser(7L, "usr-admin", "athlete-1", "athlete@example.com", null, null));
     }
 
     @Test
@@ -90,6 +92,7 @@ class CompetitionInvitationServiceTest {
 
     private static final class RecordingEmailService extends CompetitionInvitationEmailService {
         private final List<String> sentSubjects = new ArrayList<>();
+        private final List<String> sentBodies = new ArrayList<>();
 
         private RecordingEmailService() {
             super();
@@ -98,6 +101,7 @@ class CompetitionInvitationServiceTest {
         @Override
         public boolean sendInvitation(String to, String subject, String body) {
             sentSubjects.add(subject);
+            sentBodies.add(body);
             return true;
         }
     }
@@ -207,6 +211,11 @@ class CompetitionInvitationServiceTest {
 
         @Override
         public List<CompetitionInviteCandidateView> searchInviteCandidates(long competitionId, String query) {
+            return List.of();
+        }
+
+        @Override
+        public List<BootcampAthlete> listCompetitionAthletes(long competitionId) {
             return List.of();
         }
 

--- a/src/test/java/com/frankies/bootcamp/service/CompetitionSetupServiceTest.java
+++ b/src/test/java/com/frankies/bootcamp/service/CompetitionSetupServiceTest.java
@@ -41,12 +41,13 @@ class CompetitionSetupServiceTest {
 
         BootcampAthlete athlete = athlete("athlete-1", 18.0);
 
-        service.createCompetitionAndJoin(athlete, "Winter Bootcamp", "Australia/Sydney", "2026-07-01", "2026-09-30", "25");
+        long competitionId = service.createCompetitionAndJoin(athlete, "Winter Bootcamp", "Australia/Sydney", "2026-07-01", "2026-09-30", "25");
 
         assertEquals("Winter Bootcamp", dbService.createdCompetitionName);
         assertEquals("Australia/Sydney", dbService.createdCompetitionTimezone);
         assertEquals("athlete-1", dbService.createdCompetitionAthleteId);
         assertEquals(25.0, dbService.createdCompetitionGoal, 0.0001);
+        assertEquals(9L, competitionId);
         assertEquals(LocalDate.parse("2026-09-30").atStartOfDay(ZoneId.of("Australia/Sydney")).toEpochSecond(), dbService.createdCompetitionEndTimestamp);
         assertEquals(athlete, athleteRefresh.lastAthlete);
         assertEquals(1, athleteRefresh.refreshCalls);

--- a/src/test/java/com/frankies/bootcamp/servlet/BootcampServletTest.java
+++ b/src/test/java/com/frankies/bootcamp/servlet/BootcampServletTest.java
@@ -42,6 +42,12 @@ class BootcampServletTest {
         assertNull(selectedCompetitionId);
     }
 
+    @Test
+    void competitionManagementPathBypassesOnboardingGate() {
+        assertEquals(true, BootcampServlet.isCompetitionManagementPath("/bootcamp", "/bootcamp/app/competitions"));
+        assertEquals(false, BootcampServlet.isCompetitionManagementPath("/bootcamp", "/bootcamp/app"));
+    }
+
     private static OnboardingStatus status(List<CompetitionSummaryView> activeCompetitions,
                                            List<CompetitionSummaryView> pastCompetitions) {
         return new OnboardingStatus(

--- a/src/test/java/com/frankies/bootcamp/servlet/ManageCompetitionsServletTest.java
+++ b/src/test/java/com/frankies/bootcamp/servlet/ManageCompetitionsServletTest.java
@@ -1,0 +1,16 @@
+package com.frankies.bootcamp.servlet;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ManageCompetitionsServletTest {
+
+    @Test
+    void leaveErrorRedirectKeepsUserOnManagePage() {
+        assertEquals(
+                "/bootcamp/app/competitions?leaveError=last-admin",
+                ManageCompetitionsServlet.buildLeaveErrorRedirect("/bootcamp", "last-admin")
+        );
+    }
+}

--- a/src/test/java/com/frankies/bootcamp/util/EmailDisplayUtilTest.java
+++ b/src/test/java/com/frankies/bootcamp/util/EmailDisplayUtilTest.java
@@ -1,0 +1,17 @@
+package com.frankies.bootcamp.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class EmailDisplayUtilTest {
+    @Test
+    void masksTypicalEmailAddress() {
+        assertEquals("f***s@gmail.com", EmailDisplayUtil.maskEmail("francois@gmail.com"));
+    }
+
+    @Test
+    void leavesNonEmailValuesUntouched() {
+        assertEquals("not-an-email", EmailDisplayUtil.maskEmail("not-an-email"));
+    }
+}


### PR DESCRIPTION
Store the active dashboard tab in the URL query string and restore it on page load so pull-to-refresh keeps the athlete on their current tab while preserving landing/tab audit behavior.